### PR TITLE
Always require just one approval for membership

### DIFF
--- a/src/SelfService/Domain/Services/MembershipApplicationDomainService.cs
+++ b/src/SelfService/Domain/Services/MembershipApplicationDomainService.cs
@@ -16,31 +16,11 @@ public class MembershipApplicationDomainService
 
     public async Task<bool> CanBeFinalized(MembershipApplication application)
     {
-        var memberships = await _membershipRepository.FindBy(application.CapabilityId);
-
-        var currentMemberCount = memberships.Count();
         var approvalCount = application.Approvals.Count();
 
-        if (currentMemberCount == 1)
+        if (approvalCount >= 1)
         {
-            if (approvalCount == 1)
-            {
-                return true;
-            }
-        }
-        else if (currentMemberCount == 2)
-        {
-            if (approvalCount >= 1)
-            {
-                return true;
-            }
-        }
-        else if (currentMemberCount > 2)
-        {
-            if (approvalCount >= 2)
-            {
-                return true;
-            }
+            return true;
         }
 
         return false;


### PR DESCRIPTION
Simpler to understand for the users, less code, and based in as much necessity as the old decision