### PR TITLE
fix: Removed legacy DB connection string

### DIFF
--- a/k8s/deployment.yml
+++ b/k8s/deployment.yml
@@ -36,11 +36,6 @@ spec:
                 secretKeyRef:
                   name: selfservice-api-postgres
                   key: PGCONNSTRING
-            - name: SS_LEGACY_CONNECTION_STRING
-              valueFrom:
-                secretKeyRef:
-                  name: capability-service-db
-                  key: connection-string
             - name: DEFAULT_KAFKA_GROUP_ID
               value: build.selfservice.selfservice-api
             - name: SS_APISPECS_TOPIC


### PR DESCRIPTION
As part of https://github.com/orgs/dfds/projects/25/views/15?pane=issue&itemId=31593537 quite a few secrets were removed. 

Currently the new selfservice-api deployment Kubernetes manifest has a reference to one of those old secrets. This PR removes that.

As far as I can see, the selfservice-api application itself doesn't make use of it?