### PR TITLE
Added additional ingress for selfservice-api

### DIFF
--- a/k8s/ingressroute.yml
+++ b/k8s/ingressroute.yml
@@ -17,6 +17,17 @@ spec:
           name: selfservice-api
           namespace: selfservice
           port: external
+    - kind: Rule
+      match: Host(`api.hellman.oxygen.dfds.cloud`) && PathPrefix(`/ssu/api`)
+      priority: 101
+      middlewares:
+        - name: selfservice-api-pub
+          namespace: selfservice
+      services:
+        - kind: Service
+          name: selfservice-api
+          namespace: selfservice
+          port: external
 ---
 apiVersion: traefik.containo.us/v1alpha1
 kind: Middleware
@@ -27,3 +38,13 @@ spec:
   stripPrefix:
     prefixes:
       - /api
+---
+apiVersion: traefik.containo.us/v1alpha1
+kind: Middleware
+metadata:
+  name: selfservice-api-pub
+  namespace: selfservice
+spec:
+  stripPrefix:
+    prefixes:
+      - /ssu/api


### PR DESCRIPTION
The predecessor to _selfservice-api_, _capability-service_, had an IngressRoute that allowed access to the API.

The API at the time was protected with OAuth, and seemingly 99% of selfservice-api is too. I've checked all routes in the openapi spec, and only found one route that wasn't protected (_/apispecs_).

Feel free to raise any concerns.