### PR TITLE
Add consumers link on topic response

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "dotnet-reportgenerator-globaltool": {
-      "version": "5.1.17",
+      "version": "7.0.9",
       "commands": [
         "reportgenerator"
       ]

--- a/src/SelfService/Domain/Services/AuthorizationService.cs
+++ b/src/SelfService/Domain/Services/AuthorizationService.cs
@@ -76,6 +76,15 @@ public class AuthorizationService : IAuthorizationService
         return false;
     }
 
+    public async Task<bool> CanReadConsumers(PortalUser portalUser, KafkaTopic kafkaTopic)
+    {
+        if (await _membershipQuery.HasActiveMembership(portalUser.Id, kafkaTopic.CapabilityId))
+        {
+            return true;
+        }
+        return false;
+    }
+
     public async Task<bool> CanReadMessageContracts(PortalUser portalUser, KafkaTopic kafkaTopic)
     {
         if (kafkaTopic.IsPublic || await _membershipQuery.HasActiveMembership(portalUser.Id, kafkaTopic.CapabilityId))

--- a/src/SelfService/Domain/Services/IAuthorizationService.cs
+++ b/src/SelfService/Domain/Services/IAuthorizationService.cs
@@ -9,6 +9,7 @@ public interface IAuthorizationService
     Task<bool> CanChange(PortalUser portalUser, KafkaTopic kafkaTopic);
     Task<bool> CanDelete(PortalUser portalUser, KafkaTopic kafkaTopic);
     Task<bool> CanReadMessageContracts(PortalUser portalUser, KafkaTopic kafkaTopic);
+    Task<bool> CanReadConsumers(PortalUser portalUser, KafkaTopic kafkaTopic);
     Task<bool> CanAddMessageContract(PortalUser portalUser, KafkaTopic kafkaTopic);
 
     Task<bool> CanViewAccess(UserId userId, CapabilityId capabilityId);

--- a/src/SelfService/Infrastructure/Api/ApiResourceFactory.cs
+++ b/src/SelfService/Infrastructure/Api/ApiResourceFactory.cs
@@ -64,6 +64,12 @@ public class ApiResourceFactory
             allowOnSelf += Delete;
         }
 
+        var consumerAccessLevel = Allow.None;
+        if (await _authorizationService.CanReadConsumers(portalUser, topic))
+        {
+            consumerAccessLevel += Get;
+        }
+
         var messageContractsAccessLevel = Allow.None;
         if (await _authorizationService.CanReadMessageContracts(portalUser, topic))
         {
@@ -107,6 +113,16 @@ public class ApiResourceFactory
                     Rel = "related",
                     Allow = messageContractsAccessLevel
                 },
+                Consumers = new ResourceLink
+                {
+                    Href = _linkGenerator.GetUriByAction(
+                        httpContext: HttpContext,
+                        action: nameof(KafkaTopicController.GetConsumers),
+                        controller: GetNameOf<KafkaTopicController>(),
+                        values: new { id = topic.Id }) ?? "?",
+                    Rel = "related",
+                    Allow = consumerAccessLevel
+                },
                 UpdateDescription = await _authorizationService.CanChange(portalUser, topic)
                     ? new ResourceActionLink
                     {
@@ -114,7 +130,7 @@ public class ApiResourceFactory
                             httpContext: HttpContext,
                             action: nameof(KafkaTopicController.ChangeTopicDescription),
                             controller: GetNameOf<KafkaTopicController>(),
-                            values: new { id = topic.Id }) ?? "",
+                            values: new { id = topic.Id }) ?? "?",
                         Method = "PUT",
                     }
                     : null
@@ -471,6 +487,31 @@ public class ApiResourceFactory
                         action: nameof(KafkaTopicController.GetMessageContracts),
                         controller: GetNameOf<KafkaTopicController>(),
                         values: new { id = parentKafkaTopic.Id }) ?? "",
+                    Rel = "self",
+                    Allow = allowedInteractions
+                }
+            }
+        };
+    }
+
+    public async Task<ConsumersListApiResource> Convert(IEnumerable<string> consumers,
+        KafkaTopic topic)
+    {
+        var allowedInteractions = Allow.Get;
+
+        return new ConsumersListApiResource
+        {
+            Items = consumers
+                .ToArray(),
+            Links =
+            {
+                Self = new ResourceLink
+                {
+                    Href = _linkGenerator.GetUriByAction(
+                        httpContext: HttpContext,
+                        action: nameof(KafkaTopicController.GetConsumers),
+                        controller: GetNameOf<KafkaTopicController>(),
+                        values: new { topicId = topic.Id, clusterId = topic.KafkaClusterId }) ?? "",
                     Rel = "self",
                     Allow = allowedInteractions
                 }

--- a/src/SelfService/Infrastructure/Api/Capabilities/ConsumersListApiResource.cs
+++ b/src/SelfService/Infrastructure/Api/Capabilities/ConsumersListApiResource.cs
@@ -1,0 +1,16 @@
+using System.Text.Json.Serialization;
+
+namespace SelfService.Infrastructure.Api.Capabilities;
+
+public class ConsumersListApiResource
+{
+    public string[] Items { get; set; }
+
+    [JsonPropertyName("_links")]
+    public ConsumerListLinks Links { get; set; } = new();
+
+    public class ConsumerListLinks
+    {
+        public ResourceLink Self { get; set; } = new();
+    }
+}

--- a/src/SelfService/Infrastructure/Api/Capabilities/KafkaTopicApiResource.cs
+++ b/src/SelfService/Infrastructure/Api/Capabilities/KafkaTopicApiResource.cs
@@ -20,6 +20,7 @@ public class KafkaTopicApiResource
     {
         public ResourceLink Self { get; set; } = new();
         public ResourceLink MessageContracts { get; set; } = new();
+        public ResourceLink Consumers { get; set; } = new();
         public ResourceActionLink? UpdateDescription { get; set; }
     }
 }


### PR DESCRIPTION
Lets the API return _links-item for fetching consumers.

Currently always returns an empty list