### PR TITLE
Getting topic names out of database is now less strict in terms of value validation

### DIFF
--- a/src/SelfService.Tests/Domain/Models/TestKafkaTopicName.cs
+++ b/src/SelfService.Tests/Domain/Models/TestKafkaTopicName.cs
@@ -87,7 +87,8 @@ public class TestKafkaTopicName
     [InlineData("foo.BAR")]
     public void try_parse_returns_expected_instance_when_parsing_valid_input(string validInput)
     {
-        KafkaTopicName.TryParse(validInput, out var result);
+        var valid = KafkaTopicName.TryParse(validInput, out var result);
+        Assert.True(valid);
         Assert.Equal("foo.bar", result);
     }
 
@@ -101,8 +102,9 @@ public class TestKafkaTopicName
     [Fact]
     public void try_parse_returns_expected_instance_when_parsing_invalid_input()
     {
-        KafkaTopicName.TryParse("foo bar", out var result);
-        Assert.Null(result);
+        var valid = KafkaTopicName.TryParse("foo bar", out var result);
+        Assert.False(valid);
+        Assert.Equal("foo bar", result);
     }
 
     [Fact]

--- a/src/SelfService/Domain/Models/KafkaTopicName.cs
+++ b/src/SelfService/Domain/Models/KafkaTopicName.cs
@@ -88,14 +88,8 @@ public class KafkaTopicName : ValueObject
 
     public static bool TryParse(string? text, out KafkaTopicName topicName)
     {
-        if (IsValid(text))
-        {
-            topicName = new KafkaTopicName(text!.ToLowerInvariant());
-            return true;
-        }
-
-        topicName = null!;
-        return false;
+        topicName = new KafkaTopicName(text!.ToLowerInvariant());
+        return IsValid(text);
     }
 
     public CapabilityId ExtractCapabilityId()

--- a/src/SelfService/Infrastructure/Persistence/Converters/KafkaTopicNameConverter.cs
+++ b/src/SelfService/Infrastructure/Persistence/Converters/KafkaTopicNameConverter.cs
@@ -10,7 +10,12 @@ public class KafkaTopicNameConverter : ValueConverter<KafkaTopicName, string>
     {
             
     }
-
     private static Expression<Func<KafkaTopicName, string>> ToDatabaseType => id => id.ToString();
-    private static Expression<Func<string, KafkaTopicName>> FromDatabaseType => value => KafkaTopicName.Parse(value);
+    private static Expression<Func<string, KafkaTopicName>> FromDatabaseType => value => Parse(value);
+    
+    private static KafkaTopicName Parse(string value)
+    {
+        KafkaTopicName.TryParse(value, out var payload); // TODO: Consider adding additional logging if validation fails
+        return payload;
+    }
 }


### PR DESCRIPTION
For context, see: https://github.com/dfds/cloudplatform/issues/1780

Screenshots:

Still denying creation of topic that fails the regex:
<img width="1418" alt="image" src="https://github.com/dfds/selfservice-api/assets/1633308/96815182-5855-47dd-920c-27c45bd8b6c6">

Will allow listing/reading topics that fails the regex now:
<img width="1418" alt="image" src="https://github.com/dfds/selfservice-api/assets/1633308/45821f55-1132-435f-92d1-06502cb59237">
