### PR TITLE
Cleanup/1835 remove compiler warnings

### DIFF
--- a/src/SelfService.Tests/Application/TestAwsAccountApplicationService.cs
+++ b/src/SelfService.Tests/Application/TestAwsAccountApplicationService.cs
@@ -87,7 +87,7 @@ public class TestAwsAccountApplicationService
 
         await sut.CreateAwsAccountRequestTicket(id: AwsAccountId.New());
 
-        Assert.Empty(spy.Headers);
+        Assert.Empty(spy.Headers!);
     }
 
     #region Test Doubles
@@ -172,7 +172,7 @@ public class TestAwsAccountApplicationService
         }
 
         public string? Message { get; private set; }
-        public IDictionary<string, string> Headers { get; set; }
+        public IDictionary<string, string>? Headers { get; set; }
     }
 
     #endregion

--- a/src/SelfService.Tests/Infrastructure/Api/KafkaTopicRoutes/when_changing_kafka_topic_description_as_NON_member_of_owning_capability.cs
+++ b/src/SelfService.Tests/Infrastructure/Api/KafkaTopicRoutes/when_changing_kafka_topic_description_as_NON_member_of_owning_capability.cs
@@ -35,9 +35,10 @@ public class when_changing_kafka_topic_description_as_NON_member_of_owning_capab
     }
 
     [Fact]
-    public async Task then_response_has_expected_status_code()
+    public Task then_response_has_expected_status_code()
     {
         Assert.Equal((HttpStatusCode) 401, _response.StatusCode);
+        return Task.CompletedTask;
     }
 
     public Task DisposeAsync()

--- a/src/SelfService.Tests/Infrastructure/Api/KafkaTopicRoutes/when_changing_kafka_topic_description_as_member_of_owning_capability.cs
+++ b/src/SelfService.Tests/Infrastructure/Api/KafkaTopicRoutes/when_changing_kafka_topic_description_as_member_of_owning_capability.cs
@@ -35,9 +35,10 @@ public class when_changing_kafka_topic_description_as_member_of_owning_capabilit
     }
 
     [Fact]
-    public async Task then_response_has_expected_status_code()
+    public Task then_response_has_expected_status_code()
     {
         Assert.Equal((HttpStatusCode) 204, _response.StatusCode);
+        return Task.CompletedTask;
     }
 
     public Task DisposeAsync()

--- a/src/SelfService.Tests/Infrastructure/Api/KafkaTopicRoutes/when_changing_kafka_topic_description_with_invalid_input_as_member_of_owning_capability.cs
+++ b/src/SelfService.Tests/Infrastructure/Api/KafkaTopicRoutes/when_changing_kafka_topic_description_with_invalid_input_as_member_of_owning_capability.cs
@@ -35,15 +35,17 @@ public class when_changing_kafka_topic_description_with_invalid_input_as_member_
     }
 
     [Fact]
-    public async Task then_response_has_expected_status_code()
+    public Task then_response_has_expected_status_code()
     {
         Assert.Equal((HttpStatusCode) 400, _response.StatusCode);
+        return Task.CompletedTask;
     }
 
     [Fact]
-    public async Task then_response_payload_is_problem_details()
+    public Task then_response_payload_is_problem_details()
     {
         Assert.Equal("application/problem+json", _response.Content.Headers.ContentType?.MediaType);
+        return Task.CompletedTask;
     }
 
     public Task DisposeAsync()

--- a/src/SelfService.Tests/Infrastructure/Api/KafkaTopicRoutes/when_deleting_a_private_kafka_topic_as_NON_member_of_owning_capability.cs
+++ b/src/SelfService.Tests/Infrastructure/Api/KafkaTopicRoutes/when_deleting_a_private_kafka_topic_as_NON_member_of_owning_capability.cs
@@ -27,9 +27,10 @@ public class when_deleting_a_private_kafka_topic_as_NON_member_of_owning_capabil
     }
 
     [Fact]
-    public async Task then_response_has_expected_status_code()
+    public Task then_response_has_expected_status_code()
     {
         Assert.Equal((HttpStatusCode) 401, _response.StatusCode);
+        return Task.CompletedTask;
     }
 
     public Task DisposeAsync()

--- a/src/SelfService.Tests/Infrastructure/Api/KafkaTopicRoutes/when_deleting_a_private_kafka_topic_as_cloud_engineer.cs
+++ b/src/SelfService.Tests/Infrastructure/Api/KafkaTopicRoutes/when_deleting_a_private_kafka_topic_as_cloud_engineer.cs
@@ -32,9 +32,10 @@ public class when_deleting_a_private_kafka_topic_as_cloud_engineer: IAsyncLifeti
     }
 
     [Fact]
-    public async Task then_response_has_expected_status_code()
+    public Task then_response_has_expected_status_code()
     {
         Assert.Equal((HttpStatusCode) 401, _response.StatusCode);
+        return Task.CompletedTask;
     }
 
     public Task DisposeAsync()

--- a/src/SelfService.Tests/Infrastructure/Api/KafkaTopicRoutes/when_deleting_a_private_kafka_topic_as_member_of_owning_capability.cs
+++ b/src/SelfService.Tests/Infrastructure/Api/KafkaTopicRoutes/when_deleting_a_private_kafka_topic_as_member_of_owning_capability.cs
@@ -27,9 +27,10 @@ public class when_deleting_a_private_kafka_topic_as_member_of_owning_capability 
     }
 
     [Fact]
-    public async Task then_response_has_expected_status_code()
+    public Task then_response_has_expected_status_code()
     {
         Assert.Equal((HttpStatusCode) 204, _response.StatusCode);
+        return Task.CompletedTask;
     }
 
     public Task DisposeAsync()

--- a/src/SelfService.Tests/Infrastructure/Api/KafkaTopicRoutes/when_deleting_a_public_kafka_topic_as_NON_member_of_owning_capability.cs
+++ b/src/SelfService.Tests/Infrastructure/Api/KafkaTopicRoutes/when_deleting_a_public_kafka_topic_as_NON_member_of_owning_capability.cs
@@ -27,9 +27,10 @@ public class when_deleting_a_public_kafka_topic_as_NON_member_of_owning_capabili
     }
 
     [Fact]
-    public async Task then_response_has_expected_status_code()
+    public Task then_response_has_expected_status_code()
     {
         Assert.Equal((HttpStatusCode) 401, _response.StatusCode);
+        return Task.CompletedTask;
     }
 
     public Task DisposeAsync()

--- a/src/SelfService.Tests/Infrastructure/Api/KafkaTopicRoutes/when_deleting_a_public_kafka_topic_as_cloud_engineer.cs
+++ b/src/SelfService.Tests/Infrastructure/Api/KafkaTopicRoutes/when_deleting_a_public_kafka_topic_as_cloud_engineer.cs
@@ -32,9 +32,10 @@ public class when_deleting_a_public_kafka_topic_as_cloud_engineer: IAsyncLifetim
     }
 
     [Fact]
-    public async Task then_response_has_expected_status_code()
+    public Task then_response_has_expected_status_code()
     {
         Assert.Equal((HttpStatusCode) 204, _response.StatusCode);
+        return Task.CompletedTask;
     }
 
     public Task DisposeAsync()

--- a/src/SelfService.Tests/Infrastructure/Api/KafkaTopicRoutes/when_deleting_a_public_kafka_topic_as_member_of_owning_capability.cs
+++ b/src/SelfService.Tests/Infrastructure/Api/KafkaTopicRoutes/when_deleting_a_public_kafka_topic_as_member_of_owning_capability.cs
@@ -27,9 +27,10 @@ public class when_deleting_a_public_kafka_topic_as_member_of_owning_capability :
     }
 
     [Fact]
-    public async Task then_response_has_expected_status_code()
+    public Task then_response_has_expected_status_code()
     {
         Assert.Equal((HttpStatusCode) 401, _response.StatusCode);
+        return Task.CompletedTask;
     }
 
     public Task DisposeAsync()

--- a/src/SelfService.Tests/Infrastructure/Api/KafkaTopicRoutes/when_getting_private_topics_as_a_cloud_engineer.cs
+++ b/src/SelfService.Tests/Infrastructure/Api/KafkaTopicRoutes/when_getting_private_topics_as_a_cloud_engineer.cs
@@ -33,9 +33,10 @@ public class when_getting_private_topics_as_a_cloud_engineer : IAsyncLifetime
     }
 
     [Fact]
-    public async Task then_response_status_code_is_expected()
+    public Task then_response_status_code_is_expected()
     {
         Assert.Equal((HttpStatusCode) 200, _response.StatusCode);
+        return Task.CompletedTask;
     }
 
     [Fact]

--- a/src/SelfService.Tests/Infrastructure/Api/KafkaTopicRoutes/when_getting_public_topics_as_a_cloud_engineer.cs
+++ b/src/SelfService.Tests/Infrastructure/Api/KafkaTopicRoutes/when_getting_public_topics_as_a_cloud_engineer.cs
@@ -39,9 +39,10 @@ public class when_getting_public_topics_as_a_cloud_engineer : IAsyncLifetime
     }
 
     [Fact]
-    public async Task then_response_status_code_is_expected()
+    public Task then_response_status_code_is_expected()
     {
         Assert.Equal((HttpStatusCode) 200, _response.StatusCode);
+        return Task.CompletedTask;
     }
 
     [Fact]

--- a/src/SelfService.Tests/Infrastructure/Api/MembershipApplicationRoutes/when_getting_membership_application_approvals_as_NON_member.cs
+++ b/src/SelfService.Tests/Infrastructure/Api/MembershipApplicationRoutes/when_getting_membership_application_approvals_as_NON_member.cs
@@ -25,9 +25,10 @@ public class when_getting_membership_application_approvals_as_NON_member : IAsyn
     }
 
     [Fact]
-    public async Task then_returns_unauthorized()
+    public Task then_returns_unauthorized()
     {
         Assert.Equal(HttpStatusCode.Unauthorized, _response.StatusCode);
+        return Task.CompletedTask;
     }
 
     public Task DisposeAsync()

--- a/src/SelfService.Tests/Infrastructure/Api/MembershipApplicationRoutes/when_getting_membership_application_approvals_that_does_NOT_exist.cs
+++ b/src/SelfService.Tests/Infrastructure/Api/MembershipApplicationRoutes/when_getting_membership_application_approvals_that_does_NOT_exist.cs
@@ -20,9 +20,10 @@ public class when_getting_membership_application_approvals_that_does_NOT_exist :
     }
 
     [Fact]
-    public async Task then_returns_not_found()
+    public Task then_returns_not_found()
     {
         Assert.Equal(HttpStatusCode.NotFound, _response.StatusCode);
+        return Task.CompletedTask;
     }
 
     public Task DisposeAsync()

--- a/src/SelfService.Tests/Infrastructure/Api/MembershipApplicationRoutes/when_getting_membership_application_for_another_applicant_as_NON_member.cs
+++ b/src/SelfService.Tests/Infrastructure/Api/MembershipApplicationRoutes/when_getting_membership_application_for_another_applicant_as_NON_member.cs
@@ -24,9 +24,10 @@ public class when_getting_membership_application_for_another_applicant_as_NON_me
     }
 
     [Fact]
-    public async Task then_returns_unauthorized()
+    public Task then_returns_unauthorized()
     {
         Assert.Equal(HttpStatusCode.Unauthorized, _response.StatusCode);
+        return Task.CompletedTask;
     }
 
     public Task DisposeAsync()

--- a/src/SelfService.Tests/Infrastructure/Api/MembershipApplicationRoutes/when_getting_membership_application_that_does_NOT_exist.cs
+++ b/src/SelfService.Tests/Infrastructure/Api/MembershipApplicationRoutes/when_getting_membership_application_that_does_NOT_exist.cs
@@ -20,9 +20,10 @@ public class when_getting_membership_application_that_does_NOT_exist : IAsyncLif
     }
 
     [Fact]
-    public async Task then_returns_not_found()
+    public Task then_returns_not_found()
     {
         Assert.Equal(HttpStatusCode.NotFound, _response.StatusCode);
+        return Task.CompletedTask;
     }
 
     public Task DisposeAsync()

--- a/src/SelfService/Application/MembershipApplicationService.cs
+++ b/src/SelfService/Application/MembershipApplicationService.cs
@@ -115,7 +115,7 @@ public class MembershipApplicationService : IMembershipApplicationService
 
         var application = await _membershipApplicationRepository.Get(applicationId);
 
-        if (await _membershipApplicationDomainService.CanBeFinalized(application))
+        if (_membershipApplicationDomainService.CanBeFinalized(application))
         {
             application.FinalizeApprovals();
 

--- a/src/SelfService/Domain/Models/IMembershipRepository.cs
+++ b/src/SelfService/Domain/Models/IMembershipRepository.cs
@@ -4,5 +4,5 @@ public interface IMembershipRepository
 {
     Task Add(Membership membership);
     Task<IEnumerable<Membership>> FindBy(CapabilityId capabilityId);
-    Task<Membership> Cancel(CapabilityId capabilityId, UserId userId);
+    Task<Membership?> Cancel(CapabilityId capabilityId, UserId userId);
 }

--- a/src/SelfService/Domain/Models/MembershipApplicationStatusOptions.cs
+++ b/src/SelfService/Domain/Models/MembershipApplicationStatusOptions.cs
@@ -1,10 +1,64 @@
 namespace SelfService.Domain.Models;
 
-[Obsolete("Turn this into a value object instead (see MessageContractStatus)")]
-public enum MembershipApplicationStatusOptions
+public class MembershipApplicationStatusOptions: ValueObject
 {
-    Unknown = 0,
-    PendingApprovals,
-    Finalized,
-    Cancelled
+    public static readonly MembershipApplicationStatusOptions Unknown = new("Unknown");
+    public static readonly MembershipApplicationStatusOptions PendingApprovals = new("PendingApprovals");
+    public static readonly MembershipApplicationStatusOptions Finalized = new("Finalized");
+    public static readonly MembershipApplicationStatusOptions Cancelled = new("Cancelled");
+
+    private readonly string _value;
+
+    private MembershipApplicationStatusOptions(string value)
+    {
+        _value = value;
+    }
+
+    protected override IEnumerable<object> GetEqualityComponents()
+    {
+        yield return _value;
+    }
+
+    public override string ToString()
+    {
+        return _value;
+    }
+
+    public static MembershipApplicationStatusOptions Parse(string? text)
+    {
+        if (TryParse(text, out var status))
+        {
+            return status;
+        }
+
+        throw new FormatException($"Value \"{text}\" is not valid.");
+    }
+
+    public static bool TryParse(string? text, out MembershipApplicationStatusOptions status)
+    {
+        var input = text ?? "";
+
+        foreach (var value in Values)
+        {
+            if (value.ToString().Equals(input, StringComparison.InvariantCultureIgnoreCase))
+            {
+                status = value;
+                return true;
+            }
+        }
+
+        status = null!;
+        return false;
+    }
+
+    public static IReadOnlyCollection<MembershipApplicationStatusOptions> Values => new[]
+    {
+        Unknown, PendingApprovals, Finalized, Cancelled
+    };
+
+    public static implicit operator MembershipApplicationStatusOptions(string text)
+        => Parse(text);
+
+    public static implicit operator string(MembershipApplicationStatusOptions status)
+        => status.ToString();
 }

--- a/src/SelfService/Domain/Services/MembershipApplicationDomainService.cs
+++ b/src/SelfService/Domain/Services/MembershipApplicationDomainService.cs
@@ -14,7 +14,7 @@ public class MembershipApplicationDomainService
         _membershipQuery = membershipQuery;
     }
 
-    public async Task<bool> CanBeFinalized(MembershipApplication application)
+    public bool CanBeFinalized(MembershipApplication application)
     {
         var approvalCount = application.Approvals.Count();
 

--- a/src/SelfService/Infrastructure/Api/ApiResourceFactory.cs
+++ b/src/SelfService/Infrastructure/Api/ApiResourceFactory.cs
@@ -259,7 +259,7 @@ public class ApiResourceFactory
         };
     }
 
-    private async Task<ResourceLink> CreateMembersLinkFor(Capability capability)
+    private ResourceLink CreateMembersLinkFor(Capability capability)
     {
         return new ResourceLink
         {
@@ -323,7 +323,7 @@ public class ApiResourceFactory
             Links =
             {
                 Self = CreateSelfLinkFor(capability),
-                Members = await CreateMembersLinkFor(capability),
+                Members = CreateMembersLinkFor(capability),
                 Clusters = CreateClusterAccessLinkFor(capability),
                 MembershipApplications = await CreateMembershipApplicationsLinkFor(capability),
                 LeaveCapability = await CreateLeaveCapabilityLinkFor(capability),

--- a/src/SelfService/Infrastructure/Api/System/SystemController.cs
+++ b/src/SelfService/Infrastructure/Api/System/SystemController.cs
@@ -17,7 +17,7 @@ public class SystemController : ControllerBase
     }
 
     [HttpGet("stats/topvisitors")]
-    public async Task<IActionResult> GetTopVisitors()
+    public IActionResult GetTopVisitors()
     {
         var visitorRecords = _topVisitorsRepository.GetAll();
         return Ok(new

--- a/src/SelfService/Infrastructure/Messaging/ConsumerConfiguration.cs
+++ b/src/SelfService/Infrastructure/Messaging/ConsumerConfiguration.cs
@@ -30,7 +30,7 @@ public static class ConsumerConfiguration
                 .ForTopic($"{SelfServicePrefix}.awsaccount")
                 .Register<AwsAccountRequested>(
                     messageType: AwsAccountRequested.EventType,
-                    keySelector: x => x.AccountId
+                    keySelector: x => x.AccountId!
                 )
                 ;
 

--- a/src/SelfService/Infrastructure/Persistence/Converters/MembershipApplicationStatusOptionConverter.cs
+++ b/src/SelfService/Infrastructure/Persistence/Converters/MembershipApplicationStatusOptionConverter.cs
@@ -1,0 +1,16 @@
+using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using SelfService.Domain.Models;
+
+namespace SelfService.Infrastructure.Persistence.Converters;
+
+public class MembershipApplicationStatusOptionsConverter : ValueConverter<MembershipApplicationStatusOptions, string>
+{
+    public MembershipApplicationStatusOptionsConverter() : base(ToDatabaseType, FromDatabaseType)
+    {
+
+    }
+
+    private static Expression<Func<MembershipApplicationStatusOptions, string>> ToDatabaseType => id => id.ToString();
+    private static Expression<Func<string, MembershipApplicationStatusOptions>> FromDatabaseType => value => MembershipApplicationStatusOptions.Parse(value);
+}

--- a/src/SelfService/Infrastructure/Persistence/SelfServiceDbContext.cs
+++ b/src/SelfService/Infrastructure/Persistence/SelfServiceDbContext.cs
@@ -107,7 +107,7 @@ public class SelfServiceDbContext : DbContext
 
         configurationBuilder
             .Properties<MembershipApplicationStatusOptions>()
-            .HaveConversion<string>();
+            .HaveConversion<MembershipApplicationStatusOptionsConverter>();
 
         configurationBuilder
             .Properties<KafkaTopicPartitions>()


### PR DESCRIPTION
closes dfds/cloudplatform/issues/1835 
partially at least

# Additional Review Notes
Work in progress, but let us discuss if this is something we even want.
All remaining warnings is the same issues. We have 73 warnings remaining out of 124.

Each commit on this branch is trying to handle a single specific warning.
This allows us to pick and choose solutions how we like.
