### PR TITLE
Remove self-imposed obsoletion warning

### DIFF
--- a/src/SelfService/Domain/Models/MembershipApplicationStatusOptions.cs
+++ b/src/SelfService/Domain/Models/MembershipApplicationStatusOptions.cs
@@ -1,10 +1,64 @@
 namespace SelfService.Domain.Models;
 
-[Obsolete("Turn this into a value object instead (see MessageContractStatus)")]
-public enum MembershipApplicationStatusOptions
+public class MembershipApplicationStatusOptions: ValueObject
 {
-    Unknown = 0,
-    PendingApprovals,
-    Finalized,
-    Cancelled
+    public static readonly MembershipApplicationStatusOptions Unknown = new("Unknown");
+    public static readonly MembershipApplicationStatusOptions PendingApprovals = new("PendingApprovals");
+    public static readonly MembershipApplicationStatusOptions Finalized = new("Finalized");
+    public static readonly MembershipApplicationStatusOptions Cancelled = new("Cancelled");
+
+    private readonly string _value;
+
+    private MembershipApplicationStatusOptions(string value)
+    {
+        _value = value;
+    }
+
+    protected override IEnumerable<object> GetEqualityComponents()
+    {
+        yield return _value;
+    }
+
+    public override string ToString()
+    {
+        return _value;
+    }
+
+    public static MembershipApplicationStatusOptions Parse(string? text)
+    {
+        if (TryParse(text, out var status))
+        {
+            return status;
+        }
+
+        throw new FormatException($"Value \"{text}\" is not valid.");
+    }
+
+    public static bool TryParse(string? text, out MembershipApplicationStatusOptions status)
+    {
+        var input = text ?? "";
+
+        foreach (var value in Values)
+        {
+            if (value.ToString().Equals(input, StringComparison.InvariantCultureIgnoreCase))
+            {
+                status = value;
+                return true;
+            }
+        }
+
+        status = null!;
+        return false;
+    }
+
+    public static IReadOnlyCollection<MembershipApplicationStatusOptions> Values => new[]
+    {
+        Unknown, PendingApprovals, Finalized, Cancelled
+    };
+
+    public static implicit operator MembershipApplicationStatusOptions(string text)
+        => Parse(text);
+
+    public static implicit operator string(MembershipApplicationStatusOptions status)
+        => status.ToString();
 }

--- a/src/SelfService/Infrastructure/Persistence/Converters/MembershipApplicationStatusOptionConverter.cs
+++ b/src/SelfService/Infrastructure/Persistence/Converters/MembershipApplicationStatusOptionConverter.cs
@@ -1,0 +1,16 @@
+using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using SelfService.Domain.Models;
+
+namespace SelfService.Infrastructure.Persistence.Converters;
+
+public class MembershipApplicationStatusOptionsConverter : ValueConverter<MembershipApplicationStatusOptions, string>
+{
+    public MembershipApplicationStatusOptionsConverter() : base(ToDatabaseType, FromDatabaseType)
+    {
+
+    }
+
+    private static Expression<Func<MembershipApplicationStatusOptions, string>> ToDatabaseType => id => id.ToString();
+    private static Expression<Func<string, MembershipApplicationStatusOptions>> FromDatabaseType => value => MembershipApplicationStatusOptions.Parse(value);
+}

--- a/src/SelfService/Infrastructure/Persistence/SelfServiceDbContext.cs
+++ b/src/SelfService/Infrastructure/Persistence/SelfServiceDbContext.cs
@@ -107,7 +107,7 @@ public class SelfServiceDbContext : DbContext
 
         configurationBuilder
             .Properties<MembershipApplicationStatusOptions>()
-            .HaveConversion<string>();
+            .HaveConversion<MembershipApplicationStatusOptionsConverter>();
 
         configurationBuilder
             .Properties<KafkaTopicPartitions>()


### PR DESCRIPTION
closes dfds/cloudplatform/issues/1835
partially

# Additional Review Notes
These warnings are self-imposed.
This solution follow the suggestion from the original developers, which is more structured.
Alternatively we could simply remove the obsolete-attribute from the enum, but that would leave us with multiple different implementation styles.
Thoughts?
