### PR TITLE
Prevent warning for null possibility

### DIFF
--- a/src/SelfService/Domain/Events/AwsAccountRequested.cs
+++ b/src/SelfService/Domain/Events/AwsAccountRequested.cs
@@ -6,5 +6,5 @@ public class AwsAccountRequested : IDomainEvent
 {
     public const string EventType = "aws-account-requested";
 
-    public string? AccountId { get; set; }
+    public string AccountId { get; set; }
 }


### PR DESCRIPTION
closes dfds/cloudplatform/issues/1835
partially

# Additional Review Notes
AccountID _should_ never be a null value.
I am not 100% certain, so this might break things.