### PR TITLE
Change database schema for capability status

### DIFF
--- a/db/migrations/20230801113000_add-capability-status.sql
+++ b/db/migrations/20230801113000_add-capability-status.sql
@@ -1,9 +1,8 @@
 -- 2023-08-01 11:30:xx : Add status and modified_at to capabilities
 
--- add columns
 ALTER TABLE "Capability"
-ADD column "Status" varchar(255) NOT NULL DEFAULT 'Active',
-ADD column "ModifiedAt" timestamp NOT NULL DEFAULT clock_timestamp();
+ADD COLUMN "Status" VARCHAR(255) NOT NULL DEFAULT 'Active',
+ADD COLUMN "ModifiedAt" TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP; -- always overwritten, but non-nulls should have a default
 
 -- update status and modified_at to fit existing deletions
 -- also update modified_at to fit existing created_at
@@ -17,6 +16,5 @@ UPDATE "Capability"
 SET "ModifiedAt" = "CreatedAt"
 WHERE "Deleted" IS NULL;
 
--- remove deleted coloumn
 ALTER TABLE "Capability"
-DROP column "Deleted";
+DROP COLUMN "Deleted";

--- a/db/migrations/20230801113000_add-capability-status.sql
+++ b/db/migrations/20230801113000_add-capability-status.sql
@@ -1,0 +1,22 @@
+-- 2023-08-01 11:30:xx : Add status and modified_at to capabilities
+
+-- add columns
+ALTER TABLE "Capability"
+ADD column "Status" varchar(255) NOT NULL DEFAULT 'Active',
+ADD column "ModifiedAt" timestamp NOT NULL DEFAULT clock_timestamp();
+
+-- update status and modified_at to fit existing deletions
+-- also update modified_at to fit existing created_at
+UPDATE "Capability"
+SET
+    "Status" = 'Deleted',
+    "ModifiedAt" = "Deleted"
+WHERE "Deleted" IS NOT NULL;
+
+UPDATE "Capability"
+SET "ModifiedAt" = "CreatedAt"
+WHERE "Deleted" IS NULL;
+
+-- remove deleted coloumn
+ALTER TABLE "Capability"
+DROP column "Deleted";

--- a/db/seed/Capability.csv
+++ b/db/seed/Capability.csv
@@ -1,3 +1,4 @@
-Id;Name;Description;Deleted;CreatedAt;CreatedBy
-cloudengineering-xxx;CloudEngineering-xxx;This is cloud stuff;;2023-02-10T08:00:00;SeedScript
-marketing-department-xxx;Marketing-Department;We send emails;;2023-02-10T08:00:00;SeedScript
+Id;Name;Description;CreatedAt;CreatedBy;Status;ModifiedAt
+cloudengineering-xxx;CloudEngineering-xxx;This is cloud stuff;2023-02-10T08:00:00;SeedScript;Active;2023-02-10T08:00:00
+marketing-department-xxx;Marketing-Department;We send emails;2023-02-10T08:00:00;SeedScript;Deleted;2023-07-25T08:00:00
+pending-deletion-xxx;pending-deletion-xxx;Pending Deletion;2023-02-10T08:00:00;SeedScript;Pending Deletion;2023-02-10T08:00:00

--- a/db/seed/Member.csv
+++ b/db/seed/Member.csv
@@ -1,3 +1,5 @@
 Email;DisplayName;Id
-jandr@dfds.com;Jens Andresen;jandr@dfds.com
-thfis@dfds.com;Thomas Fischer;thfis@dfds.com
+andfris@dfds.com;Andreas Frisch;andfris@dfds.com
+krijens@dfds.com;Kristian Pilegaard Jensen;krijens@dfds.com
+pausegh@dfds.com;Paul Seghers;pausegh@dfds.com
+hritote@dfds.com;Hristiyana Toteva;hritote@dfds.com

--- a/db/seed/Membership.csv
+++ b/db/seed/Membership.csv
@@ -1,3 +1,10 @@
 CapabilityId;UserId;CreatedAt;Id
-cloudengineering-xxx;jandr@dfds.com;2023-03-17T08:00:00;35C66428-811E-41E2-9B94-8E09995A0367
-marketing-department-xxx;thfis@dfds.com;2023-04-04T16:00:00;C20C9307-55E0-4039-B034-9E061499D7B5
+cloudengineering-xxx;andfris@dfds.com;2023-03-17T08:00:00;35C66428-811E-41E2-9B94-8E09995A0367
+pending-deletion-xxx;andfris@dfds.com;2023-03-17T08:00:00;35C66428-811E-41E2-9B94-8E09995A0368
+cloudengineering-xxx;krijens@dfds.com;2023-03-17T08:00:00;cf1db68c-3073-11ee-be56-0242ac120002
+pending-deletion-xxx;krijens@dfds.com;2023-03-17T08:00:00;cf1db68c-3073-11ee-be56-0242ac120003
+cloudengineering-xxx;pausegh@dfds.com;2023-03-17T08:00:00;d40676c0-3073-11ee-be56-0242ac120002
+pending-deletion-xxx;pausegh@dfds.com;2023-03-17T08:00:00;d40676c0-3073-11ee-be56-0242ac120003
+cloudengineering-xxx;hritote@dfds.com;2023-03-17T08:00:00;daf5f5fa-3073-11ee-be56-0242ac120002
+pending-deletion-xxx;hritote@dfds.com;2023-03-17T08:00:00;daf5f5fa-3073-11ee-be56-0242ac120003
+marketing-department-xxx;andfris@dfds.com;2023-04-04T16:00:00;C20C9307-55E0-4039-B034-9E061499D7B5

--- a/db/seed/MembershipApplication.csv
+++ b/db/seed/MembershipApplication.csv
@@ -1,3 +1,2 @@
 Id;CapabilityId;Applicant;Status;SubmittedAt;ExpiresOn
 183fb4f4-9d0c-45b9-a33f-5fdcb32b88bc;cloudengineering-xxx;john@doe.com;PendingApprovals;2000-01-01;3000-01-01
-8a4908f6-7402-4ce1-82af-68f60cd06711;marketing-department-xxx;jandr@dfds.com;PendingApprovals;2000-01-01;3000-01-01

--- a/src/SelfService.Tests/Builders/CapabilityBuilder.cs
+++ b/src/SelfService.Tests/Builders/CapabilityBuilder.cs
@@ -7,8 +7,9 @@ public class CapabilityBuilder
     private CapabilityId _id;
     private string _name;
     private string _description;
-    private DateTime? _deleted;
+    private CapabilityStatusOptions _status;
     private DateTime _createdAt;
+    private DateTime _modifiedAt;
     private string _createdBy;
 
     public CapabilityBuilder()
@@ -16,8 +17,9 @@ public class CapabilityBuilder
         _id = CapabilityId.CreateFrom("foo");
         _name = "foo";
         _description = "this is foo";
-        _deleted = null;
+        _status = CapabilityStatusOptions.Active;
         _createdAt = new DateTime(2000, 1, 1);
+        _modifiedAt = new DateTime(2000, 1, 1);
         _createdBy = nameof(CapabilityBuilder);
     }
 
@@ -39,7 +41,6 @@ public class CapabilityBuilder
             id: _id,
             name: _name,
             description: _description,
-            deleted: _deleted,
             createdAt: _createdAt,
             createdBy: _createdBy
         );

--- a/src/SelfService.Tests/Comparers/CapabilityComparer.cs
+++ b/src/SelfService.Tests/Comparers/CapabilityComparer.cs
@@ -28,14 +28,15 @@ public class CapabilityComparer : IEqualityComparer<Capability?>
 
         return x.Name == y.Name
             && x.Description == y.Description
-            && Nullable.Equals(x.Deleted, y.Deleted)
+            && x.Status == y.Status
             && x.CreatedAt.Equals(y.CreatedAt)
+            && x.ModifiedAt.Equals(y.ModifiedAt)
             && x.CreatedBy == y.CreatedBy;
     }
 
     public int GetHashCode(Capability obj)
     {
-        return HashCode.Combine(obj.Name, obj.Description, obj.Deleted, obj.CreatedAt, obj.CreatedBy);
+        return HashCode.Combine(obj.Name, obj.Description, obj.Status, obj.CreatedAt, obj.ModifiedAt, obj.CreatedBy);
     }
 }
 

--- a/src/SelfService/Domain/Models/Capability.cs
+++ b/src/SelfService/Domain/Models/Capability.cs
@@ -8,7 +8,6 @@ public class Capability : AggregateRoot<CapabilityId>
         CapabilityId id,
         string name,
         string description,
-        DateTime? deleted,
         DateTime createdAt,
         string createdBy
     )
@@ -16,9 +15,10 @@ public class Capability : AggregateRoot<CapabilityId>
     {
         Name = name;
         Description = description;
-        Deleted = deleted;
         CreatedAt = createdAt;
+        Status = CapabilityStatusOptions.Active; // all new capabilities are active to begin with
         CreatedBy = createdBy;
+        ModifiedAt = createdAt; // this will always be the same as CreatedAt for a new Capability
     }
 
     public static Capability CreateCapability(
@@ -29,16 +29,16 @@ public class Capability : AggregateRoot<CapabilityId>
         string requestedBy
     )
     {
-        var capability = new Capability(capabilityId, name, description, null, creationTime, requestedBy);
+        var capability = new Capability(capabilityId, name, description, creationTime, requestedBy);
         capability.Raise(new CapabilityCreated(capabilityId, requestedBy));
         return capability;
     }
 
     public string Name { get; private set; }
     public string Description { get; set; }
-    public DateTime? Deleted { get; set; }
-
+    public CapabilityStatusOptions Status { get; set; }
     public DateTime CreatedAt { get; private set; }
+    public DateTime ModifiedAt { get; private set; }
     public string CreatedBy { get; private set; }
 
     public override string ToString()

--- a/src/SelfService/Domain/Models/CapabilityStatusOptions.cs
+++ b/src/SelfService/Domain/Models/CapabilityStatusOptions.cs
@@ -1,0 +1,59 @@
+namespace SelfService.Domain.Models;
+
+public class CapabilityStatusOptions : ValueObject
+{
+    public static readonly CapabilityStatusOptions Active = new("Active");
+    public static readonly CapabilityStatusOptions PendingDeletion = new("Pending Deletion");
+    public static readonly CapabilityStatusOptions Deleted = new("Deleted");
+
+    private readonly string _value;
+
+    private CapabilityStatusOptions(string value)
+    {
+        _value = value;
+    }
+
+    protected override IEnumerable<object> GetEqualityComponents()
+    {
+        yield return _value;
+    }
+
+    public override string ToString()
+    {
+        return _value;
+    }
+
+    public static CapabilityStatusOptions Parse(string? text)
+    {
+        if (TryParse(text, out var status))
+        {
+            return status;
+        }
+
+        throw new FormatException($"Value \"{text}\" is not valid.");
+    }
+
+    public static bool TryParse(string? text, out CapabilityStatusOptions status)
+    {
+        var input = text ?? "";
+
+        foreach (var value in Values)
+        {
+            if (value.ToString().Equals(input, StringComparison.InvariantCultureIgnoreCase))
+            {
+                status = value;
+                return true;
+            }
+        }
+
+        status = null!;
+        return false;
+    }
+
+    public static IReadOnlyCollection<CapabilityStatusOptions> Values =>
+        new[] { Active, PendingDeletion, Deleted };
+
+    public static implicit operator CapabilityStatusOptions(string text) => Parse(text);
+
+    public static implicit operator string(CapabilityStatusOptions status) => status.ToString();
+}

--- a/src/SelfService/Infrastructure/Api/Me/Module.cs
+++ b/src/SelfService/Infrastructure/Api/Me/Module.cs
@@ -95,7 +95,7 @@ public class MeController : ControllerBase
         {
             new Stat(
                 Title: "Capabilities",
-                Value: await _dbContext.Capabilities.Where(x => x.Deleted == null).CountAsync()
+                Value: await _dbContext.Capabilities.Where(x => x.Status != CapabilityStatusOptions.Deleted).CountAsync()
             ),
             new Stat(Title: "AWS Accounts", Value: await _dbContext.AwsAccounts.CountAsync()),
             new Stat(Title: "Kubernetes Clusters", Value: 1),

--- a/src/SelfService/Infrastructure/Api/Stats/StatsController.cs
+++ b/src/SelfService/Infrastructure/Api/Stats/StatsController.cs
@@ -48,7 +48,7 @@ public class StatsController : ControllerBase
     private async Task<Stat[]> ComposeStats()
     {
         //first fetch/compute the values:
-        int capabilitiesStat = await _dbContext.Capabilities.Where(x => x.Deleted == null).CountAsync();
+        int capabilitiesStat = await _dbContext.Capabilities.Where(x => x.Status != CapabilityStatusOptions.Deleted).CountAsync();
 
         int awsAccountsStat = await _dbContext.AwsAccounts.CountAsync();
 

--- a/src/SelfService/Infrastructure/Persistence/CapabilityRepository.cs
+++ b/src/SelfService/Infrastructure/Persistence/CapabilityRepository.cs
@@ -41,6 +41,6 @@ public class CapabilityRepository : ICapabilityRepository
 
     public async Task<IEnumerable<Capability>> GetAll()
     {
-        return await _dbContext.Capabilities.Where(c => c.Deleted == null).OrderBy(x => x.Name).ToListAsync();
+        return await _dbContext.Capabilities.Where(c => c.Status != CapabilityStatusOptions.Deleted).OrderBy(x => x.Name).ToListAsync();
     }
 }

--- a/src/SelfService/Infrastructure/Persistence/Converters/CapabilityStatusOptionConverter.cs
+++ b/src/SelfService/Infrastructure/Persistence/Converters/CapabilityStatusOptionConverter.cs
@@ -1,0 +1,15 @@
+using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using SelfService.Domain.Models;
+
+namespace SelfService.Infrastructure.Persistence.Converters;
+
+public class CapabilityStatusOptionsConverter : ValueConverter<CapabilityStatusOptions, string>
+{
+    public CapabilityStatusOptionsConverter()
+        : base(ToDatabaseType, FromDatabaseType) { }
+
+    private static Expression<Func<CapabilityStatusOptions, string>> ToDatabaseType => id => id.ToString();
+    private static Expression<Func<string, CapabilityStatusOptions>> FromDatabaseType =>
+        value => CapabilityStatusOptions.Parse(value);
+}

--- a/src/SelfService/Infrastructure/Persistence/Queries/AadAwsSyncCapabilityQuery.cs
+++ b/src/SelfService/Infrastructure/Persistence/Queries/AadAwsSyncCapabilityQuery.cs
@@ -49,7 +49,7 @@ public class AadAwsSyncCapabilityQuery : IAadAwsSyncCapabilityQuery
 
     private async Task<List<Capability>> GetAllActiveCapabilities()
     {
-        return await _context.Capabilities.Where(x => x.Deleted == null).ToListAsync();
+        return await _context.Capabilities.Where(x => x.Status != CapabilityStatusOptions.Deleted).ToListAsync();
     }
 
     private async Task<ILookup<CapabilityId, Membership>> GetAllMembershipByCapability()

--- a/src/SelfService/Infrastructure/Persistence/Queries/CapabilityMembersQuery.cs
+++ b/src/SelfService/Infrastructure/Persistence/Queries/CapabilityMembersQuery.cs
@@ -43,7 +43,7 @@ public class MyCapabilitiesQuery : IMyCapabilitiesQuery
             where membership.UserId == userId
             select capability;
 
-        return await query.OrderBy(x => x.Name).Where(x => x.Deleted == null).ToListAsync();
+        return await query.OrderBy(x => x.Name).Where(x => x.Status != CapabilityStatusOptions.Deleted).ToListAsync();
     }
 }
 

--- a/src/SelfService/Infrastructure/Persistence/SelfServiceDbContext.cs
+++ b/src/SelfService/Infrastructure/Persistence/SelfServiceDbContext.cs
@@ -85,6 +85,11 @@ public class SelfServiceDbContext : DbContext
             .Properties<MembershipApplicationStatusOptions>()
             .HaveConversion<MembershipApplicationStatusOptionsConverter>();
 
+        configurationBuilder
+            .Properties<CapabilityStatusOptions>()
+            .HaveConversion<CapabilityStatusOptionsConverter>();
+
+
         configurationBuilder.Properties<KafkaTopicPartitions>().HaveConversion<KafkaTopicPartitionsConverter>();
 
         configurationBuilder.Properties<KafkaTopicRetention>().HaveConversion<KafkaTopicRetentionConverter>();
@@ -123,8 +128,9 @@ public class SelfServiceDbContext : DbContext
             cfg.Property(x => x.Id).ValueGeneratedNever();
             cfg.Property(x => x.Name);
             cfg.Property(x => x.Description);
-            cfg.Property(x => x.Deleted);
+            cfg.Property(x => x.Status);
             cfg.Property(x => x.CreatedAt);
+            cfg.Property(x => x.ModifiedAt);
             cfg.Property(x => x.CreatedBy);
         });
 


### PR DESCRIPTION
closes dfds/cloudplatform/issues/1851

# Warning
Modifies existing database table and transforms the data
There is no going back from a failure

# Additional Review Notes
I have tested this locally, running the migration script against the database produced by the develop-branch using pgAdmin.
This PR is constrained to introducing the capability status and making sure everything works as expected.

Bonus: I changed the seeding scripts so that the 4 main contributors of this repository are automatically members of the dummy-capabilities present during local development

