### PR TITLE
Feature/1859 capability status manipulation

### DIFF
--- a/src/SelfService/Application/CapabilityApplicationService.cs
+++ b/src/SelfService/Application/CapabilityApplicationService.cs
@@ -44,7 +44,6 @@ public class CapabilityApplicationService : ICapabilityApplicationService
         var capability = Capability.CreateCapability(capabilityId, name, description, creationTime, requestedBy);
         await _capabilityRepository.Add(capability);
 
-        // TODO [paulseghers & thfis]: check if capability already exists in db
         return capabilityId;
     }
 
@@ -150,5 +149,34 @@ public class CapabilityApplicationService : ICapabilityApplicationService
         }
 
         kafkaClusterAccess.RegisterAsGranted(_systemTime.Now);
+    }
+
+    [TransactionalBoundary, Outboxed]
+    public async Task RequestCapabilityDeletion(
+        CapabilityId capabilityId
+    )
+    {
+        var capability = await _capabilityRepository.FindBy(capabilityId);
+        if (capability is null)
+        {
+            throw EntityNotFoundException<Capability>.UsingId(capabilityId);
+        }
+        var modificationTime = _systemTime.Now;
+        capability.RequestDeletion();
+
+    }
+
+    [TransactionalBoundary, Outboxed]
+    public async Task CancelCapabilityDeletionRequest(
+        CapabilityId capabilityId
+    )
+    {
+        var capability = await _capabilityRepository.FindBy(capabilityId);
+        if (capability is null)
+        {
+            throw EntityNotFoundException<Capability>.UsingId(capabilityId);
+        }
+        var modificationTime = _systemTime.Now;
+        capability.CancelDeletionRequest();
     }
 }

--- a/src/SelfService/Application/ICapabilityApplicationService.cs
+++ b/src/SelfService/Application/ICapabilityApplicationService.cs
@@ -23,4 +23,6 @@ public interface ICapabilityApplicationService
     );
     Task RequestKafkaClusterAccess(CapabilityId capabilityId, KafkaClusterId kafkaClusterId, UserId requestedBy);
     Task RegisterKafkaClusterAccessGranted(CapabilityId capabilityId, KafkaClusterId kafkaClusterId);
+    Task RequestCapabilityDeletion(CapabilityId capabilityId);
+    Task CancelCapabilityDeletionRequest(CapabilityId capabilityId);
 }

--- a/src/SelfService/Domain/Models/Capability.cs
+++ b/src/SelfService/Domain/Models/Capability.cs
@@ -45,4 +45,26 @@ public class Capability : AggregateRoot<CapabilityId>
     {
         return Id.ToString();
     }
+
+    public void RequestDeletion()
+    {
+        if (Status != CapabilityStatusOptions.Active)
+        {
+            throw new InvalidOperationException("Capability is not active");
+        }
+
+        Status = CapabilityStatusOptions.PendingDeletion;
+        ModifiedAt = DateTime.UtcNow;
+    }
+
+    public void CancelDeletionRequest()
+    {
+        if (Status != CapabilityStatusOptions.PendingDeletion)
+        {
+            throw new InvalidOperationException("Capability is not pending deletion");
+        }
+
+        Status = CapabilityStatusOptions.Active;
+        ModifiedAt = DateTime.UtcNow;
+    }
 }

--- a/src/SelfService/Domain/Services/AuthorizationService.cs
+++ b/src/SelfService/Domain/Services/AuthorizationService.cs
@@ -167,4 +167,9 @@ public class AuthorizationService : IAuthorizationService
     {
         return await _membershipQuery.HasActiveMembership(userId, capabilityId);
     }
+
+    public async Task<bool> CanDeleteCapability(UserId userId, CapabilityId capabilityId)
+    {
+        return await _membershipQuery.HasActiveMembership(userId, capabilityId);
+    }
 }

--- a/src/SelfService/Domain/Services/IAuthorizationService.cs
+++ b/src/SelfService/Domain/Services/IAuthorizationService.cs
@@ -22,4 +22,5 @@ public interface IAuthorizationService
     Task<bool> CanLeave(UserId userId, CapabilityId capabilityId);
     Task<bool> CanApply(UserId userId, CapabilityId capabilityId);
     Task<bool> CanViewAllApplications(UserId userId, CapabilityId capabilityId);
+    Task<bool> CanDeleteCapability(UserId userId, CapabilityId capabilityId);
 }

--- a/src/SelfService/Infrastructure/Api/ApiResourceFactory.cs
+++ b/src/SelfService/Infrastructure/Api/ApiResourceFactory.cs
@@ -194,6 +194,7 @@ public class ApiResourceFactory
         return new CapabilityListItemApiResource(
             id: capability.Id,
             name: capability.Name,
+            status: capability.Status.ToString(),
             description: capability.Description,
             links: new CapabilityListItemApiResource.CapabilityListItemLinks(
                 self: new ResourceLink(
@@ -266,6 +267,49 @@ public class ApiResourceFactory
         );
     }
 
+    private async Task<ResourceLink> CreateRequestDeletionLinkFor(Capability capability)
+    {
+        var allowedInteractions = Allow.None;
+        if (
+            await _authorizationService.CanDeleteCapability(CurrentUser, capability.Id) &&
+            capability.Status == CapabilityStatusOptions.Active
+        ) {
+            allowedInteractions += Post;
+        }
+        return new ResourceLink(
+            href: _linkGenerator.GetUriByAction(
+                httpContext: HttpContext,
+                action: nameof(CapabilityController.RequestCapabilityDeletion),
+                controller: GetNameOf<CapabilityController>(),
+                values: new { id = capability.Id }
+            ) ?? "",
+            rel: "self",
+            allow: allowedInteractions
+        );
+    }
+
+    private async Task<ResourceLink> CreateCancelDeletionRequestLinkFor(Capability capability)
+    {
+        var allowedInteractions = Allow.None;
+        if (
+            await _authorizationService.CanDeleteCapability(CurrentUser, capability.Id) &&
+            capability.Status == CapabilityStatusOptions.PendingDeletion
+        ) {
+            allowedInteractions += Post;
+        }
+
+        return new ResourceLink(
+            href: _linkGenerator.GetUriByAction(
+                httpContext: HttpContext,
+                action: nameof(CapabilityController.CancelCapabilityDeletionRequest),
+                controller: GetNameOf<CapabilityController>(),
+                values: new { id = capability.Id }
+            ) ?? "",
+            rel: "self",
+            allow: allowedInteractions
+        );
+    }
+
     private ResourceLink CreateMembersLinkFor(Capability capability)
     {
         return new ResourceLink(
@@ -325,6 +369,7 @@ public class ApiResourceFactory
         return new CapabilityDetailsApiResource(
             id: capability.Id,
             name: capability.Name,
+            status: capability.Status.ToString(),
             description: capability.Description,
             links: new CapabilityDetailsApiResource.CapabilityDetailsLinks(
                 self: CreateSelfLinkFor(capability),
@@ -332,7 +377,9 @@ public class ApiResourceFactory
                 clusters: CreateClusterAccessLinkFor(capability),
                 membershipApplications: await CreateMembershipApplicationsLinkFor(capability),
                 leaveCapability: await CreateLeaveCapabilityLinkFor(capability),
-                awsAccount: await CreateAwsAccountLinkFor(capability)
+                awsAccount: await CreateAwsAccountLinkFor(capability),
+                requestCapabilityDeletion: await CreateRequestDeletionLinkFor(capability),
+                cancelCapabilityDeletionRequest: await CreateCancelDeletionRequestLinkFor(capability)
             )
         );
     }

--- a/src/SelfService/Infrastructure/Api/ApiResourceFactory.cs
+++ b/src/SelfService/Infrastructure/Api/ApiResourceFactory.cs
@@ -271,8 +271,7 @@ public class ApiResourceFactory
     {
         var allowedInteractions = Allow.None;
         if (
-            await _authorizationService.CanDeleteCapability(CurrentUser, capability.Id) &&
-            capability.Status == CapabilityStatusOptions.Active
+            await _authorizationService.CanDeleteCapability(CurrentUser, capability.Id)
         ) {
             allowedInteractions += Post;
         }
@@ -292,8 +291,7 @@ public class ApiResourceFactory
     {
         var allowedInteractions = Allow.None;
         if (
-            await _authorizationService.CanDeleteCapability(CurrentUser, capability.Id) &&
-            capability.Status == CapabilityStatusOptions.PendingDeletion
+            await _authorizationService.CanDeleteCapability(CurrentUser, capability.Id)
         ) {
             allowedInteractions += Post;
         }

--- a/src/SelfService/Infrastructure/Api/Capabilities/CapabilityController.cs
+++ b/src/SelfService/Infrastructure/Api/Capabilities/CapabilityController.cs
@@ -684,4 +684,138 @@ public class CapabilityController : ControllerBase
             value: new { status = "Requested" }
         );
     }
+
+    [HttpPost("{id}/requestdeletion")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized, "application/problem+json")]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound, "application/problem+json")]
+    public async Task<IActionResult> RequestCapabilityDeletion(string id)
+    {
+        // Verify user and fetch userId
+        if (!User.TryGetUserId(out var userId))
+        {
+            return Unauthorized(
+                new ProblemDetails
+                {
+                    Title = "Unknown user id",
+                    Detail = $"User id is not valid and thus cannot leave any capabilities.",
+                }
+            );
+        }
+
+        // Check that capability with provided id exists
+        if (!CapabilityId.TryParse(id, out var capabilityId))
+        {
+            return NotFound(
+                new ProblemDetails
+                {
+                    Title = "Capability not found.",
+                    Detail = $"A capability with id \"{id}\" could not be found."
+                }
+            );
+        }
+
+        // deleting and canceling deletion are the same responsibility currently.
+        // thus we use the same authorization check for both
+        if (!await _authorizationService.CanDeleteCapability(userId, capabilityId))
+        {
+            return Unauthorized(
+                new ProblemDetails
+                {
+                    Title = "Not authorized",
+                    Detail = $"User \"{userId}\" is not authorized to cancel deletion request for capability \"{capabilityId}\"."
+                }
+            );
+        }
+
+        // Set capability status
+        try
+        {
+            await _capabilityApplicationService.RequestCapabilityDeletion(capabilityId);
+            return NoContent();
+        }
+        catch (EntityNotFoundException e)
+        {
+            return NotFound(
+                new ProblemDetails
+                {
+                    Title = "Capability deletion not requested.",
+                    Detail = $"error: {e.Message}"
+                }
+            );
+        }
+        catch (InvalidOperationException)
+        {
+            // fails silently
+            // users triggering this are trying to circumvent the system and we ignore them
+            return NoContent();
+        }
+    }
+
+    [HttpPost("{id}/canceldeletionrequest")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized, "application/problem+json")]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound, "application/problem+json")]
+    public async Task<IActionResult> CancelCapabilityDeletionRequest(string id)
+    {
+        // Verify user and fetch userId
+        if (!User.TryGetUserId(out var userId))
+        {
+            return Unauthorized(
+                new ProblemDetails
+                {
+                    Title = "Unknown user id",
+                    Detail = $"User id is not valid and thus cannot leave any capabilities.",
+                }
+            );
+        }
+
+        // Check that capability with provided id exists
+        if (!CapabilityId.TryParse(id, out var capabilityId))
+        {
+            return NotFound(
+                new ProblemDetails
+                {
+                    Title = "Capability not found.",
+                    Detail = $"A capability with id \"{id}\" could not be found."
+                }
+            );
+        }
+
+        // deleting and canceling deletion are the same responsibility currently.
+        // thus we use the same authorization check for both -- if you can do one, you can do the other
+        if (!await _authorizationService.CanDeleteCapability(userId, capabilityId))
+        {
+            return Unauthorized(
+                new ProblemDetails
+                {
+                    Title = "Not authorized",
+                    Detail = $"User \"{userId}\" is not authorized to cancel deletion request for capability \"{capabilityId}\"."
+                }
+            );
+        }
+
+        // Set capability status
+        try
+        {
+            await _capabilityApplicationService.CancelCapabilityDeletionRequest(capabilityId);
+            return NoContent();
+        }
+        catch (EntityNotFoundException e)
+        {
+            return NotFound(
+                new ProblemDetails
+                {
+                    Title = "Capability deletion not requested.",
+                    Detail = $"error: {e.Message}"
+                }
+            );
+        }
+        catch (InvalidOperationException)
+        {
+            // fails silently
+            // users triggering this are trying to circumvent the system and we ignore them
+            return NoContent();
+        }
+    }
 }

--- a/src/SelfService/Infrastructure/Api/Capabilities/CapabilityDetailsApiResource.cs
+++ b/src/SelfService/Infrastructure/Api/Capabilities/CapabilityDetailsApiResource.cs
@@ -1,11 +1,14 @@
 ﻿using System.Text.Json.Serialization;
+using SelfService.Domain.Models;
 
 namespace SelfService.Infrastructure.Api.Capabilities;
+
 
 public class CapabilityDetailsApiResource
 {
     public string Id { get; set; }
     public string Name { get; set; }
+    public string Status { get; set; }
     public string Description { get; set; }
 
     [JsonPropertyName("_links")]
@@ -19,6 +22,8 @@ public class CapabilityDetailsApiResource
         public ResourceLink MembershipApplications { get; set; }
         public ResourceLink LeaveCapability { get; set; }
         public ResourceLink AwsAccount { get; set; }
+        public ResourceLink RequestCapabilityDeletion { get; set; }
+        public ResourceLink CancelCapabilityDeletionRequest { get; set; }
 
         public CapabilityDetailsLinks(
             ResourceLink self,
@@ -26,7 +31,9 @@ public class CapabilityDetailsApiResource
             ResourceLink clusters,
             ResourceLink membershipApplications,
             ResourceLink leaveCapability,
-            ResourceLink awsAccount
+            ResourceLink awsAccount,
+            ResourceLink requestCapabilityDeletion,
+            ResourceLink cancelCapabilityDeletionRequest
         )
         {
             Self = self;
@@ -35,13 +42,16 @@ public class CapabilityDetailsApiResource
             MembershipApplications = membershipApplications;
             LeaveCapability = leaveCapability;
             AwsAccount = awsAccount;
+            RequestCapabilityDeletion = requestCapabilityDeletion;
+            CancelCapabilityDeletionRequest = cancelCapabilityDeletionRequest;
         }
     }
 
-    public CapabilityDetailsApiResource(string id, string name, string description, CapabilityDetailsLinks links)
+    public CapabilityDetailsApiResource(string id, string name, string status, string description, CapabilityDetailsLinks links)
     {
         Id = id;
         Name = name;
+        Status = status;
         Description = description;
         Links = links;
     }
@@ -51,6 +61,7 @@ public class CapabilityListItemApiResource
 {
     public string Id { get; set; }
     public string Name { get; set; }
+    public string Status { get; set; }
     public string Description { get; set; }
 
     [JsonPropertyName("_links")]
@@ -66,10 +77,11 @@ public class CapabilityListItemApiResource
         }
     }
 
-    public CapabilityListItemApiResource(string id, string name, string description, CapabilityListItemLinks links)
+    public CapabilityListItemApiResource(string id, string name, string status, string description, CapabilityListItemLinks links)
     {
         Id = id;
         Name = name;
+        Status = status;
         Description = description;
         Links = links;
     }


### PR DESCRIPTION
closes dfds/cloudplatform/issues/1859

# Additional Review Notes
Adding additional information to capability responses, including relevant links for requesting deletion and cancelling deletion requests for capabilities.
The status is passed along now, to allow the frontend easier access to this information than parsing _links in magic ways.
