### PR TITLE
Send topdesk ticket for longpending deletions

### DIFF
--- a/db/migrations/20230816103000_add-capability-modifiedby.sql
+++ b/db/migrations/20230816103000_add-capability-modifiedby.sql
@@ -1,0 +1,4 @@
+-- 2023-08-16 10:30:xx : Add ModifiedBy to capabilities
+
+ALTER TABLE "Capability"
+ADD COLUMN "ModifiedBy"  varchar(255) default null;

--- a/db/seed/Capability.csv
+++ b/db/seed/Capability.csv
@@ -1,4 +1,4 @@
-Id;Name;Description;CreatedAt;CreatedBy;Status;ModifiedAt
-cloudengineering-xxx;CloudEngineering-xxx;This is cloud stuff;2023-02-10T08:00:00;SeedScript;Active;2023-02-10T08:00:00
-marketing-department-xxx;Marketing-Department;We send emails;2023-02-10T08:00:00;SeedScript;Deleted;2023-07-25T08:00:00
-pending-deletion-xxx;pending-deletion-xxx;Pending Deletion;2023-02-10T08:00:00;SeedScript;Pending Deletion;2023-02-10T08:00:00
+Id;Name;Description;CreatedAt;CreatedBy;Status;ModifiedAt,ModifiedBy
+cloudengineering-xxx;CloudEngineering-xxx;This is cloud stuff;2023-02-10T08:00:00;SeedScript;Active;2023-02-10T08:00:00;SeedScript
+marketing-department-xxx;Marketing-Department;We send emails;2023-02-10T08:00:00;SeedScript;Deleted;2023-07-25T08:00:00;SeedScript
+pending-deletion-xxx;pending-deletion-xxx;Pending Deletion;2023-02-10T08:00:00;SeedScript;Pending Deletion;2023-02-10T08:00:00;SeedScript

--- a/src/SelfService.Tests/Application/TestAwsAccountApplicationService.cs
+++ b/src/SelfService.Tests/Application/TestAwsAccountApplicationService.cs
@@ -167,6 +167,11 @@ public class TestAwsAccountApplicationService
         {
             throw new NotImplementedException();
         }
+
+        public Task<IEnumerable<Capability>> GetAllPendingDeletion()
+        {
+            throw new NotImplementedException();
+        }
     }
 
     private class TicketingSystemSpy : ITicketingSystem

--- a/src/SelfService.Tests/Application/TestAwsAccountApplicationService.cs
+++ b/src/SelfService.Tests/Application/TestAwsAccountApplicationService.cs
@@ -168,7 +168,7 @@ public class TestAwsAccountApplicationService
             throw new NotImplementedException();
         }
 
-        public Task<IEnumerable<Capability>> GetAllPendingDeletion()
+        public Task<IEnumerable<Capability>> GetAllPendingDeletionFor(int days)
         {
             throw new NotImplementedException();
         }

--- a/src/SelfService.Tests/Builders/CapabilityBuilder.cs
+++ b/src/SelfService.Tests/Builders/CapabilityBuilder.cs
@@ -18,8 +18,8 @@ public class CapabilityBuilder
         _name = "foo";
         _description = "this is foo";
         _status = CapabilityStatusOptions.Active;
-        _createdAt = new DateTime(2000, 1, 1);
-        _modifiedAt = new DateTime(2000, 1, 1);
+        _createdAt = DateTime.Now;
+        _modifiedAt = DateTime.Now;
         _createdBy = nameof(CapabilityBuilder);
     }
 
@@ -34,16 +34,36 @@ public class CapabilityBuilder
         _name = name;
         return this;
     }
+    public CapabilityBuilder WithModifiedAt(DateTime modifiedAt)
+    {
+        _modifiedAt = modifiedAt;
+        return this;
+    }
+    public CapabilityBuilder WithDescription(string description)
+    {
+        _description = description;
+        return this;
+    }
+
+    public CapabilityBuilder WithStatus(CapabilityStatusOptions status)
+    {
+        _status = status;
+        return this;
+    }
 
     public Capability Build()
     {
-        return new Capability(
+        var c = new Capability(
             id: _id,
             name: _name,
             description: _description,
             createdAt: _createdAt,
             createdBy: _createdBy
         );
+        c.Status = _status;
+        c.SetModifiedDate(_modifiedAt);
+
+        return c;
     }
 
     public static implicit operator Capability(CapabilityBuilder builder) => builder.Build();

--- a/src/SelfService.Tests/Comparers/CapabilityComparer.cs
+++ b/src/SelfService.Tests/Comparers/CapabilityComparer.cs
@@ -38,7 +38,7 @@ public class CapabilityComparer : IEqualityComparer<Capability?>
 
     public int GetHashCode(Capability obj)
     {
-        return HashCode.Combine(obj.Name, obj.Description, obj.Status, obj.CreatedAt, obj.ModifiedAt, obj.CreatedBy);
+        return HashCode.Combine(obj.Id, obj.Name, obj.Description, obj.Status, obj.CreatedAt, obj.ModifiedAt, obj.CreatedBy, obj.ModifiedBy);
     }
 }
 

--- a/src/SelfService.Tests/Comparers/CapabilityComparer.cs
+++ b/src/SelfService.Tests/Comparers/CapabilityComparer.cs
@@ -26,12 +26,14 @@ public class CapabilityComparer : IEqualityComparer<Capability?>
             return false;
         }
 
-        return x.Name == y.Name
+        return x.Id == y.Id
+            && x.Name == y.Name
             && x.Description == y.Description
             && x.Status == y.Status
             && x.CreatedAt.Equals(y.CreatedAt)
             && x.ModifiedAt.Equals(y.ModifiedAt)
-            && x.CreatedBy == y.CreatedBy;
+            && x.CreatedBy == y.CreatedBy
+            && x.ModifiedBy == y.ModifiedBy;
     }
 
     public int GetHashCode(Capability obj)

--- a/src/SelfService.Tests/Infrastructure/Persistence/TestCapabilityRepository.cs
+++ b/src/SelfService.Tests/Infrastructure/Persistence/TestCapabilityRepository.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.EntityFrameworkCore;
 using SelfService.Tests.Comparers;
+using SelfService.Domain.Models;
 
 namespace SelfService.Tests.Infrastructure.Persistence;
 
@@ -22,5 +23,34 @@ public class TestCapabilityRepository
 
         var inserted = Assert.Single(await dbContext.Capabilities.ToListAsync());
         Assert.Equal(stub, inserted, new CapabilityComparer());
+    }
+
+    [Fact]
+    [Trait("Category", "InMemoryDatabase")]
+    public async Task getting_pending_deletions_with_days_return_only_capabilities_ready_for_deletion()
+    {
+        await using var databaseFactory = new InMemoryDatabaseFactory();
+        var dbContext = await databaseFactory.CreateDbContext();
+        var repo = A.CapabilityRepository.WithDbContext(dbContext).Build();
+
+        await repo.Add(A.Capability.WithId("active"));
+        await repo.Add(A.Capability.WithId("pending-new")
+            .WithStatus(CapabilityStatusOptions.PendingDeletion));
+        await repo.Add(A.Capability.WithId("pending-old")
+            .WithStatus(CapabilityStatusOptions.PendingDeletion)
+            .WithModifiedAt(DateTime.UtcNow.AddDays(-8))
+        );
+        await repo.Add(A.Capability.WithId("deleted")
+            .WithStatus(CapabilityStatusOptions.Deleted)
+        );
+
+        await dbContext.SaveChangesAsync();
+
+        var allCapabilities = await repo.GetAll(); // does not get deleted
+        var readyForDeletion = await repo.GetAllPendingDeletionFor(days: 7);
+
+        Assert.Equal(3, allCapabilities.Count());
+        Assert.Single(readyForDeletion);
+        Assert.Equal("pending-old", readyForDeletion.First().Id);
     }
 }

--- a/src/SelfService.Tests/TestDoubles/StubCapabilityRepository.cs
+++ b/src/SelfService.Tests/TestDoubles/StubCapabilityRepository.cs
@@ -35,4 +35,9 @@ public class StubCapabilityRepository : ICapabilityRepository
     {
         throw new NotImplementedException();
     }
+
+    public Task<IEnumerable<Capability>> GetAllPendingDeletion()
+    {
+        throw new NotImplementedException();
+    }
 }

--- a/src/SelfService.Tests/TestDoubles/StubCapabilityRepository.cs
+++ b/src/SelfService.Tests/TestDoubles/StubCapabilityRepository.cs
@@ -36,7 +36,7 @@ public class StubCapabilityRepository : ICapabilityRepository
         throw new NotImplementedException();
     }
 
-    public Task<IEnumerable<Capability>> GetAllPendingDeletion()
+    public Task<IEnumerable<Capability>> GetAllPendingDeletionFor(int days)
     {
         throw new NotImplementedException();
     }

--- a/src/SelfService/Application/ICapabilityApplicationService.cs
+++ b/src/SelfService/Application/ICapabilityApplicationService.cs
@@ -25,5 +25,5 @@ public interface ICapabilityApplicationService
     Task RegisterKafkaClusterAccessGranted(CapabilityId capabilityId, KafkaClusterId kafkaClusterId);
     Task RequestCapabilityDeletion(CapabilityId capabilityId, UserId userId);
     Task CancelCapabilityDeletionRequest(CapabilityId capabilityId, UserId userId);
-    Task CheckPendingCapabilityDeletions();
+    Task ActOnPendingCapabilityDeletions();
 }

--- a/src/SelfService/Application/ICapabilityApplicationService.cs
+++ b/src/SelfService/Application/ICapabilityApplicationService.cs
@@ -23,7 +23,7 @@ public interface ICapabilityApplicationService
     );
     Task RequestKafkaClusterAccess(CapabilityId capabilityId, KafkaClusterId kafkaClusterId, UserId requestedBy);
     Task RegisterKafkaClusterAccessGranted(CapabilityId capabilityId, KafkaClusterId kafkaClusterId);
-    Task RequestCapabilityDeletion(CapabilityId capabilityId);
-    Task CancelCapabilityDeletionRequest(CapabilityId capabilityId);
+    Task RequestCapabilityDeletion(CapabilityId capabilityId, UserId userId);
+    Task CancelCapabilityDeletionRequest(CapabilityId capabilityId, UserId userId);
     Task CheckPendingCapabilityDeletions();
 }

--- a/src/SelfService/Application/ICapabilityApplicationService.cs
+++ b/src/SelfService/Application/ICapabilityApplicationService.cs
@@ -25,4 +25,5 @@ public interface ICapabilityApplicationService
     Task RegisterKafkaClusterAccessGranted(CapabilityId capabilityId, KafkaClusterId kafkaClusterId);
     Task RequestCapabilityDeletion(CapabilityId capabilityId);
     Task CancelCapabilityDeletionRequest(CapabilityId capabilityId);
+    Task CheckPendingCapabilityDeletions();
 }

--- a/src/SelfService/Configuration/Domain.cs
+++ b/src/SelfService/Configuration/Domain.cs
@@ -69,7 +69,7 @@ public static class Domain
         builder.Services.AddHostedService<CancelExpiredMembershipApplications>();
         //builder.Services.AddHostedService<RemoveInactiveMemberships>();
         builder.Services.AddHostedService<PortalVisitAnalyzer>();
-        builder.Services.AddHostedService<CheckPendingCapabilityDeletions>();
+        builder.Services.AddHostedService<ActOnPendingCapabilityDeletions>();
 
         // misc
         builder.Services.AddTransient<IDbTransactionFacade, RealDbTransactionFacade>();

--- a/src/SelfService/Configuration/Domain.cs
+++ b/src/SelfService/Configuration/Domain.cs
@@ -69,6 +69,7 @@ public static class Domain
         builder.Services.AddHostedService<CancelExpiredMembershipApplications>();
         //builder.Services.AddHostedService<RemoveInactiveMemberships>();
         builder.Services.AddHostedService<PortalVisitAnalyzer>();
+        builder.Services.AddHostedService<CheckPendingCapabilityDeletions>();
 
         // misc
         builder.Services.AddTransient<IDbTransactionFacade, RealDbTransactionFacade>();

--- a/src/SelfService/Domain/Models/Capability.cs
+++ b/src/SelfService/Domain/Models/Capability.cs
@@ -61,4 +61,8 @@ public class Capability : AggregateRoot<CapabilityId>
         Status = CapabilityStatusOptions.Active;
         ModifiedAt = DateTime.UtcNow;
     }
+
+    public bool HasBeenPendingFor(int days) {
+        return Status == CapabilityStatusOptions.PendingDeletion && DateTime.UtcNow.Subtract(ModifiedAt).Days >= days;
+    }
 }

--- a/src/SelfService/Domain/Models/Capability.cs
+++ b/src/SelfService/Domain/Models/Capability.cs
@@ -54,6 +54,11 @@ public class Capability : AggregateRoot<CapabilityId>
         ModifiedBy = userId;
     }
 
+    public void SetModifiedDate(DateTime modifiedAt)
+    {
+        ModifiedAt = modifiedAt;
+    }
+
     public void CancelDeletionRequest(UserId userId)
     {
         if (Status != CapabilityStatusOptions.PendingDeletion)
@@ -64,10 +69,6 @@ public class Capability : AggregateRoot<CapabilityId>
         Status = CapabilityStatusOptions.Active;
         ModifiedAt = DateTime.UtcNow;
         ModifiedBy = userId;
-    }
-
-    public bool HasBeenPendingFor(int days) {
-        return Status == CapabilityStatusOptions.PendingDeletion && DateTime.UtcNow.Subtract(ModifiedAt).Days >= days;
     }
 
     public void MarkAsDeleted() {

--- a/src/SelfService/Domain/Models/Capability.cs
+++ b/src/SelfService/Domain/Models/Capability.cs
@@ -13,6 +13,7 @@ public class Capability : AggregateRoot<CapabilityId>
         Status = CapabilityStatusOptions.Active; // all new capabilities are active to begin with
         CreatedBy = createdBy;
         ModifiedAt = createdAt; // this will always be the same as CreatedAt for a new Capability
+        ModifiedBy = createdBy;
     }
 
     public static Capability CreateCapability(
@@ -34,13 +35,14 @@ public class Capability : AggregateRoot<CapabilityId>
     public DateTime CreatedAt { get; private set; }
     public DateTime ModifiedAt { get; private set; }
     public string CreatedBy { get; private set; }
+    public string ModifiedBy { get; private set; }
 
     public override string ToString()
     {
         return Id.ToString();
     }
 
-    public void RequestDeletion()
+    public void RequestDeletion(UserId userId)
     {
         if (Status != CapabilityStatusOptions.Active)
         {
@@ -49,9 +51,10 @@ public class Capability : AggregateRoot<CapabilityId>
 
         Status = CapabilityStatusOptions.PendingDeletion;
         ModifiedAt = DateTime.UtcNow;
+        ModifiedBy = userId;
     }
 
-    public void CancelDeletionRequest()
+    public void CancelDeletionRequest(UserId userId)
     {
         if (Status != CapabilityStatusOptions.PendingDeletion)
         {
@@ -60,9 +63,20 @@ public class Capability : AggregateRoot<CapabilityId>
 
         Status = CapabilityStatusOptions.Active;
         ModifiedAt = DateTime.UtcNow;
+        ModifiedBy = userId;
     }
 
     public bool HasBeenPendingFor(int days) {
         return Status == CapabilityStatusOptions.PendingDeletion && DateTime.UtcNow.Subtract(ModifiedAt).Days >= days;
+    }
+
+    public void MarkAsDeleted() {
+        if (Status != CapabilityStatusOptions.PendingDeletion)
+        {
+            throw new InvalidOperationException("Capability is not pending deletion");
+        }
+
+        Status = CapabilityStatusOptions.Deleted;
+        ModifiedAt = DateTime.UtcNow;
     }
 }

--- a/src/SelfService/Domain/Models/ICapabilityRepository.cs
+++ b/src/SelfService/Domain/Models/ICapabilityRepository.cs
@@ -7,5 +7,5 @@ public interface ICapabilityRepository
     Task<bool> Exists(CapabilityId id);
     Task Add(Capability capability);
     Task<IEnumerable<Capability>> GetAll();
-    Task<IEnumerable<Capability>> GetAllPendingDeletion();
+    Task<IEnumerable<Capability>> GetAllPendingDeletionFor(int days);
 }

--- a/src/SelfService/Domain/Models/ICapabilityRepository.cs
+++ b/src/SelfService/Domain/Models/ICapabilityRepository.cs
@@ -7,4 +7,5 @@ public interface ICapabilityRepository
     Task<bool> Exists(CapabilityId id);
     Task Add(Capability capability);
     Task<IEnumerable<Capability>> GetAll();
+    Task<IEnumerable<Capability>> GetAllPendingDeletion();
 }

--- a/src/SelfService/Infrastructure/Api/ApiResourceFactory.cs
+++ b/src/SelfService/Infrastructure/Api/ApiResourceFactory.cs
@@ -280,7 +280,7 @@ public class ApiResourceFactory
                 httpContext: HttpContext,
                 action: nameof(CapabilityController.RequestCapabilityDeletion),
                 controller: GetNameOf<CapabilityController>(),
-                values: new { id = capability.Id }
+                values: new { id = capability.Id, user = CurrentUser }
             ) ?? "",
             rel: "self",
             allow: allowedInteractions

--- a/src/SelfService/Infrastructure/Api/Capabilities/CapabilityController.cs
+++ b/src/SelfService/Infrastructure/Api/Capabilities/CapabilityController.cs
@@ -694,7 +694,7 @@ public class CapabilityController : ControllerBase
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized, "application/problem+json")]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound, "application/problem+json")]
-    public async Task<IActionResult> RequestCapabilityDeletion(string id)
+    public async Task<IActionResult> RequestCapabilityDeletion(string id, UserId user)
     {
         // Verify user and fetch userId
         if (!User.TryGetUserId(out var userId))
@@ -737,7 +737,7 @@ public class CapabilityController : ControllerBase
         // Set capability status
         try
         {
-            await _capabilityApplicationService.RequestCapabilityDeletion(capabilityId);
+            await _capabilityApplicationService.RequestCapabilityDeletion(capabilityId, userId);
             return NoContent();
         }
         catch (EntityNotFoundException e)
@@ -801,7 +801,7 @@ public class CapabilityController : ControllerBase
         // Set capability status
         try
         {
-            await _capabilityApplicationService.CancelCapabilityDeletionRequest(capabilityId);
+            await _capabilityApplicationService.CancelCapabilityDeletionRequest(capabilityId, userId);
             return NoContent();
         }
         catch (EntityNotFoundException e)

--- a/src/SelfService/Infrastructure/BackgroundJobs/CheckPendingCapabilityDeletions.cs
+++ b/src/SelfService/Infrastructure/BackgroundJobs/CheckPendingCapabilityDeletions.cs
@@ -2,11 +2,11 @@ using SelfService.Application;
 
 namespace SelfService.Infrastructure.BackgroundJobs;
 
-public class CheckPendingCapabilityDeletions : BackgroundService
+public class ActOnPendingCapabilityDeletions : BackgroundService
 {
     private readonly IServiceProvider _serviceProvider;
 
-    public CheckPendingCapabilityDeletions(IServiceProvider serviceProvider)
+    public ActOnPendingCapabilityDeletions(IServiceProvider serviceProvider)
     {
         _serviceProvider = serviceProvider;
     }
@@ -29,17 +29,17 @@ public class CheckPendingCapabilityDeletions : BackgroundService
     private async Task DoWork(CancellationToken cancellationToken)
     {
         using var scope = _serviceProvider.CreateScope();
-        var logger = scope.ServiceProvider.GetRequiredService<ILogger<CheckPendingCapabilityDeletions>>();
+        var logger = scope.ServiceProvider.GetRequiredService<ILogger<ActOnPendingCapabilityDeletions>>();
 
         using var _ = logger.BeginScope(
             "{BackgroundJob} {CorrelationId}",
-            nameof(CheckPendingCapabilityDeletions),
+            nameof(ActOnPendingCapabilityDeletions),
             Guid.NewGuid()
         );
 
         var applicationService = scope.ServiceProvider.GetRequiredService<ICapabilityApplicationService>();
 
         logger.LogDebug("Checking all currently pending deletion requests for capabilities...");
-        await applicationService.CheckPendingCapabilityDeletions();
+        await applicationService.ActOnPendingCapabilityDeletions();
     }
 }

--- a/src/SelfService/Infrastructure/BackgroundJobs/CheckPendingCapabilityDeletions.cs
+++ b/src/SelfService/Infrastructure/BackgroundJobs/CheckPendingCapabilityDeletions.cs
@@ -1,0 +1,45 @@
+using SelfService.Application;
+
+namespace SelfService.Infrastructure.BackgroundJobs;
+
+public class CheckPendingCapabilityDeletions : BackgroundService
+{
+    private readonly IServiceProvider _serviceProvider;
+
+    public CheckPendingCapabilityDeletions(IServiceProvider serviceProvider)
+    {
+        _serviceProvider = serviceProvider;
+    }
+
+    protected override Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        return Task.Run(
+            async () =>
+            {
+                while (!stoppingToken.IsCancellationRequested)
+                {
+                    await DoWork(stoppingToken);
+                    await Task.Delay(TimeSpan.FromHours(12), stoppingToken); // arbitrary long check-cycle.
+                }
+            },
+            stoppingToken
+        );
+    }
+
+    private async Task DoWork(CancellationToken cancellationToken)
+    {
+        using var scope = _serviceProvider.CreateScope();
+        var logger = scope.ServiceProvider.GetRequiredService<ILogger<CheckPendingCapabilityDeletions>>();
+
+        using var _ = logger.BeginScope(
+            "{BackgroundJob} {CorrelationId}",
+            nameof(CheckPendingCapabilityDeletions),
+            Guid.NewGuid()
+        );
+
+        var applicationService = scope.ServiceProvider.GetRequiredService<ICapabilityApplicationService>();
+
+        logger.LogDebug("Checking all currently pending deletion requests for capabilities...");
+        await applicationService.CheckPendingCapabilityDeletions();
+    }
+}

--- a/src/SelfService/Infrastructure/Persistence/CapabilityRepository.cs
+++ b/src/SelfService/Infrastructure/Persistence/CapabilityRepository.cs
@@ -47,10 +47,11 @@ public class CapabilityRepository : ICapabilityRepository
             .ToListAsync();
     }
 
-    public async Task<IEnumerable<Capability>> GetAllPendingDeletion()
+    public async Task<IEnumerable<Capability>> GetAllPendingDeletionFor(int days)
     {
+        var targetDate = DateTime.UtcNow.Subtract(TimeSpan.FromDays(days));
         return await _dbContext.Capabilities
-            .Where(c => c.Status == CapabilityStatusOptions.PendingDeletion)
+            .Where(c => c.Status == CapabilityStatusOptions.PendingDeletion && c.ModifiedAt <= targetDate)
             .OrderBy(x => x.Name)
             .ToListAsync();
     }

--- a/src/SelfService/Infrastructure/Persistence/CapabilityRepository.cs
+++ b/src/SelfService/Infrastructure/Persistence/CapabilityRepository.cs
@@ -46,4 +46,12 @@ public class CapabilityRepository : ICapabilityRepository
             .OrderBy(x => x.Name)
             .ToListAsync();
     }
+
+    public async Task<IEnumerable<Capability>> GetAllPendingDeletion()
+    {
+        return await _dbContext.Capabilities
+            .Where(c => c.Status == CapabilityStatusOptions.PendingDeletion)
+            .OrderBy(x => x.Name)
+            .ToListAsync();
+    }
 }


### PR DESCRIPTION
closes dfds/cloudplatform/issues/1870

# Question
This is technically enough, but it would be worthwhile knowing who requested the deletion in the first place.
I originally meant to create a table for managing state history like this, but was told not to spend time on this.
Question now is, do we want to extend our `Capability` table with a column for `ModifiedBy` as well?

It is not a hard thing to add, but it may not be the right solution.
On the other hand; It might be a fine solution whilst awaiting the real ownership and state management 🤷 

# Additional Review Notes
This (should) solve the ticket, but it feels half-baked. See above question.