### PR TITLE
Adding regression test for serialization of DomainEvents

### DIFF
--- a/src/SelfService.Tests/Infrastructure/Messaging/TestDafdaSerializationDeserialization.cs
+++ b/src/SelfService.Tests/Infrastructure/Messaging/TestDafdaSerializationDeserialization.cs
@@ -3,10 +3,11 @@ using System.Text.Json.Serialization;
 using Dafda.Serializing;
 using SelfService.Domain.Events;
 using SelfService.Domain.Models;
+using SelfService.Infrastructure.Messaging;
 
 namespace SelfService.Tests.Infrastructure.Messaging;
 
-public class TestDomainEventsDafdaDeserialization
+public class TestDafdaSerializationDeserialization
 {
     // Copy of code in Dafda.JsonFactory
     private readonly JsonSerializerOptions _jsonSerializerOptions =
@@ -189,5 +190,49 @@ public class TestDomainEventsDafdaDeserialization
                 UserId = TestUser
             }
         );
+    }
+
+    [Fact]
+    public async Task dafda_serialize_deserialize_kafka_cluster_access_granted()
+    {
+        await dafda_serialize_deserialize(new KafkaClusterAccessGranted());
+        await dafda_serialize_deserialize(
+            new KafkaClusterAccessGranted { CapabilityId = TestCapabilityId, KafkaClusterId = TestKafkaClusterId, }
+        );
+    }
+
+    [Fact]
+    public async Task dafda_serialize_deserialize_kafka_topic_provisioning_has_begun()
+    {
+        await dafda_serialize_deserialize(new KafkaTopicProvisioningHasBegun());
+        await dafda_serialize_deserialize(
+            new KafkaTopicProvisioningHasBegun
+            {
+                ClusterId = TestKafkaClusterId,
+                TopicId = TestTopicId,
+                TopicName = TestTopicName
+            }
+        );
+    }
+
+    [Fact]
+    public async Task dafda_serialize_deserialize_kafka_topic_provisioning_has_completed()
+    {
+        await dafda_serialize_deserialize(new KafkaTopicProvisioningHasCompleted());
+        await dafda_serialize_deserialize(
+            new KafkaTopicProvisioningHasCompleted
+            {
+                ClusterId = TestKafkaClusterId,
+                TopicId = TestTopicId,
+                TopicName = TestTopicName
+            }
+        );
+    }
+
+    [Fact]
+    public async Task dafda_serialize_deserialize_schema_registered()
+    {
+        await dafda_serialize_deserialize(new SchemaRegistered());
+        await dafda_serialize_deserialize(new SchemaRegistered { MessageContractId = TestMessageContractId });
     }
 }

--- a/src/SelfService.Tests/Infrastructure/Messaging/TestDomainEventsDafdaDeserialization.cs
+++ b/src/SelfService.Tests/Infrastructure/Messaging/TestDomainEventsDafdaDeserialization.cs
@@ -30,12 +30,13 @@ public class TestDomainEventsDafdaDeserialization
     private const string TestSchema = "schema";
     private const string TestMemberShipId = "membershipId";
 
-
-    private async Task dafda_serialize_deserialize<T>(T domainEvent) where T : IDomainEvent
+    private async Task dafda_serialize_deserialize<T>(T domainEvent)
+        where T : IDomainEvent
     {
         DefaultPayloadSerializer serializer = new DefaultPayloadSerializer();
-        var serialized = await serializer.Serialize(new PayloadDescriptor("", "", "", "", domainEvent,
-            new KeyValuePair<string, string>[] { }));
+        var serialized = await serializer.Serialize(
+            new PayloadDescriptor("", "", "", "", domainEvent, new KeyValuePair<string, string>[] { })
+        );
 
         JsonSerializer.Deserialize(serialized, typeof(T), _jsonSerializerOptions);
     }
@@ -57,123 +58,136 @@ public class TestDomainEventsDafdaDeserialization
     public async Task dafda_serialize_deserialize_kafka_cluster_access_requested()
     {
         await dafda_serialize_deserialize(new KafkaClusterAccessRequested());
-        await dafda_serialize_deserialize(new KafkaClusterAccessRequested()
-            { CapabilityId = TestCapabilityId, KafkaClusterId = TestKafkaClusterId });
+        await dafda_serialize_deserialize(
+            new KafkaClusterAccessRequested() { CapabilityId = TestCapabilityId, KafkaClusterId = TestKafkaClusterId }
+        );
     }
 
     [Fact]
     public async Task dafda_serialize_deserialize_kafka_topic_deleted()
     {
         await dafda_serialize_deserialize(new KafkaTopicHasBeenDeleted());
-        await dafda_serialize_deserialize(new  KafkaTopicHasBeenDeleted() { KafkaTopicId = TestTopicId });
+        await dafda_serialize_deserialize(new KafkaTopicHasBeenDeleted() { KafkaTopicId = TestTopicId });
     }
 
     [Fact]
     public async Task dafda_serialize_deserialize_membership_application_cancelled()
     {
         await dafda_serialize_deserialize(new MembershipApplicationHasBeenCancelled());
-        await dafda_serialize_deserialize(new MembershipApplicationHasBeenCancelled()
-            { MembershipApplicationId = TestApplicationId });
+        await dafda_serialize_deserialize(
+            new MembershipApplicationHasBeenCancelled() { MembershipApplicationId = TestApplicationId }
+        );
     }
 
     [Fact]
     public async Task dafda_serialize_deserialize_membership_application_finalized()
     {
         await dafda_serialize_deserialize(new MembershipApplicationHasBeenFinalized());
-        await dafda_serialize_deserialize(new MembershipApplicationHasBeenFinalized() { MembershipApplicationId = TestApplicationId });
+        await dafda_serialize_deserialize(
+            new MembershipApplicationHasBeenFinalized() { MembershipApplicationId = TestApplicationId }
+        );
     }
 
     [Fact]
     public async Task dafda_serialize_deserialize_membership_application_approval_received()
     {
         await dafda_serialize_deserialize(new MembershipApplicationHasReceivedAnApproval());
-        await dafda_serialize_deserialize(new MembershipApplicationHasReceivedAnApproval() { MembershipApplicationId = TestApplicationId });
+        await dafda_serialize_deserialize(
+            new MembershipApplicationHasReceivedAnApproval() { MembershipApplicationId = TestApplicationId }
+        );
     }
 
     [Fact]
     public async Task dafda_serialize_deserialize_new_kafka_topic_requested()
     {
         await dafda_serialize_deserialize(new NewKafkaTopicHasBeenRequested());
-        await dafda_serialize_deserialize(new NewKafkaTopicHasBeenRequested
-        {
-            CapabilityId = TestCapabilityId,
-            KafkaClusterId = TestKafkaClusterId,
-            KafkaTopicId = TestTopicId,
-            KafkaTopicName = TestTopicName
-        });
+        await dafda_serialize_deserialize(
+            new NewKafkaTopicHasBeenRequested
+            {
+                CapabilityId = TestCapabilityId,
+                KafkaClusterId = TestKafkaClusterId,
+                KafkaTopicId = TestTopicId,
+                KafkaTopicName = TestTopicName
+            }
+        );
     }
 
     [Fact]
     public async Task dafda_serialize_deserialize_new_membership_application_submitted()
     {
         await dafda_serialize_deserialize(new NewMembershipApplicationHasBeenSubmitted());
-        await dafda_serialize_deserialize(new NewMembershipApplicationHasBeenSubmitted
-        {
-            MembershipApplicationId = TestApplicationId
-        });
+        await dafda_serialize_deserialize(
+            new NewMembershipApplicationHasBeenSubmitted { MembershipApplicationId = TestApplicationId }
+        );
     }
 
     [Fact]
     public async Task dafda_serialize_deserialize_new_message_contract_provisioned()
     {
         await dafda_serialize_deserialize(new NewMessageContractHasBeenProvisioned());
-        await dafda_serialize_deserialize(new NewMessageContractHasBeenProvisioned
-        {
-            KafkaTopicId = TestTopicId,
-            MessageContractId = TestMessageContractId,
-            MessageType = TestMessageType
-        });
+        await dafda_serialize_deserialize(
+            new NewMessageContractHasBeenProvisioned
+            {
+                KafkaTopicId = TestTopicId,
+                MessageContractId = TestMessageContractId,
+                MessageType = TestMessageType
+            }
+        );
     }
 
     [Fact]
     public async Task dafda_serialize_deserialize_new_message_contract_requested()
     {
         await dafda_serialize_deserialize(new NewMessageContractHasBeenRequested());
-        await dafda_serialize_deserialize(new NewMessageContractHasBeenRequested
-        {
-            CapabilityId = TestCapabilityId,
-            Description = TestDescription,
-            KafkaClusterId = TestKafkaClusterId,
-            KafkaTopicId = TestTopicId,
-            KafkaTopicName = TestTopicName,
-            MessageContractId = TestMessageContractId,
-            MessageType = TestMessageType,
-            Schema = TestSchema,
-        });
+        await dafda_serialize_deserialize(
+            new NewMessageContractHasBeenRequested
+            {
+                CapabilityId = TestCapabilityId,
+                Description = TestDescription,
+                KafkaClusterId = TestKafkaClusterId,
+                KafkaTopicId = TestTopicId,
+                KafkaTopicName = TestTopicName,
+                MessageContractId = TestMessageContractId,
+                MessageType = TestMessageType,
+                Schema = TestSchema,
+            }
+        );
     }
 
     [Fact]
     public async Task dafda_serialize_deserialize_new_portal_visit_registered()
     {
         await dafda_serialize_deserialize(new NewPortalVisitRegistered());
-        await dafda_serialize_deserialize(new NewPortalVisitRegistered
-        {
-            PortalVisitId = TestPortalVisitId,
-            VisitedAt = "now",
-            VisitedBy = TestUser
-        });
+        await dafda_serialize_deserialize(
+            new NewPortalVisitRegistered
+            {
+                PortalVisitId = TestPortalVisitId,
+                VisitedAt = "now",
+                VisitedBy = TestUser
+            }
+        );
     }
 
     [Fact]
     public async Task dafda_serialize_deserialize_user_joined_capability()
     {
         await dafda_serialize_deserialize(new UserHasJoinedCapability());
-        await dafda_serialize_deserialize(new UserHasJoinedCapability
-        {
-            CapabilityId = TestCapabilityId,
-            MembershipId = TestMemberShipId
-        });
+        await dafda_serialize_deserialize(
+            new UserHasJoinedCapability { CapabilityId = TestCapabilityId, MembershipId = TestMemberShipId }
+        );
     }
 
     [Fact]
     public async Task dafda_serialize_deserialize_user_left_capability()
     {
         await dafda_serialize_deserialize(new UserHasLeftCapability());
-        await dafda_serialize_deserialize(new UserHasLeftCapability
-        {
-            CapabilityId = TestCapabilityId,
-            MembershipId = TestMemberShipId,
-            UserId = TestUser
-        });
+        await dafda_serialize_deserialize(
+            new UserHasLeftCapability
+            {
+                CapabilityId = TestCapabilityId,
+                MembershipId = TestMemberShipId,
+                UserId = TestUser
+            }
+        );
     }
 }

--- a/src/SelfService.Tests/Infrastructure/Messaging/TestDomainEventsDafdaDeserialization.cs
+++ b/src/SelfService.Tests/Infrastructure/Messaging/TestDomainEventsDafdaDeserialization.cs
@@ -1,0 +1,179 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Dafda.Serializing;
+using SelfService.Domain.Events;
+using SelfService.Domain.Models;
+
+namespace SelfService.Tests.Infrastructure.Messaging;
+
+public class TestDomainEventsDafdaDeserialization
+{
+    // Copy of code in Dafda.JsonFactory
+    private readonly JsonSerializerOptions _jsonSerializerOptions =
+        new()
+        {
+            PropertyNameCaseInsensitive = true,
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            NumberHandling = JsonNumberHandling.AllowReadingFromString
+        };
+
+    private const string TestApplicationId = "applicationId";
+    private const string TestCapabilityId = "capabilityId";
+    private const string TestUser = "user";
+    private const string TestKafkaClusterId = "clusterId";
+    private const string TestTopicId = "topicId";
+    private const string TestTopicName = "topicName";
+    private const string TestMessageType = "messageType";
+    private const string TestMessageContractId = "contractId";
+    private const string TestPortalVisitId = "portalVisitId";
+    private const string TestDescription = "description";
+    private const string TestSchema = "schema";
+    private const string TestMemberShipId = "membershipId";
+
+
+    private async Task dafda_serialize_deserialize<T>(T domainEvent) where T : IDomainEvent
+    {
+        DefaultPayloadSerializer serializer = new DefaultPayloadSerializer();
+        var serialized = await serializer.Serialize(new PayloadDescriptor("", "", "", "", domainEvent,
+            new KeyValuePair<string, string>[] { }));
+
+        JsonSerializer.Deserialize(serialized, typeof(T), _jsonSerializerOptions);
+    }
+
+    [Fact]
+    public async Task dafda_serialize_deserialize_aws_account_requested()
+    {
+        await dafda_serialize_deserialize(new AwsAccountRequested { AccountId = Guid.NewGuid().ToString() });
+        await dafda_serialize_deserialize(new AwsAccountRequested());
+    }
+
+    [Fact]
+    public async Task dafda_serialize_deserialize_capability_created()
+    {
+        await dafda_serialize_deserialize(new CapabilityCreated(TestCapabilityId, TestUser));
+    }
+
+    [Fact]
+    public async Task dafda_serialize_deserialize_kafka_cluster_access_requested()
+    {
+        await dafda_serialize_deserialize(new KafkaClusterAccessRequested());
+        await dafda_serialize_deserialize(new KafkaClusterAccessRequested()
+            { CapabilityId = TestCapabilityId, KafkaClusterId = TestKafkaClusterId });
+    }
+
+    [Fact]
+    public async Task dafda_serialize_deserialize_kafka_topic_deleted()
+    {
+        await dafda_serialize_deserialize(new KafkaTopicHasBeenDeleted());
+        await dafda_serialize_deserialize(new  KafkaTopicHasBeenDeleted() { KafkaTopicId = TestTopicId });
+    }
+
+    [Fact]
+    public async Task dafda_serialize_deserialize_membership_application_cancelled()
+    {
+        await dafda_serialize_deserialize(new MembershipApplicationHasBeenCancelled());
+        await dafda_serialize_deserialize(new MembershipApplicationHasBeenCancelled()
+            { MembershipApplicationId = TestApplicationId });
+    }
+
+    [Fact]
+    public async Task dafda_serialize_deserialize_membership_application_finalized()
+    {
+        await dafda_serialize_deserialize(new MembershipApplicationHasBeenFinalized());
+        await dafda_serialize_deserialize(new MembershipApplicationHasBeenFinalized() { MembershipApplicationId = TestApplicationId });
+    }
+
+    [Fact]
+    public async Task dafda_serialize_deserialize_membership_application_approval_received()
+    {
+        await dafda_serialize_deserialize(new MembershipApplicationHasReceivedAnApproval());
+        await dafda_serialize_deserialize(new MembershipApplicationHasReceivedAnApproval() { MembershipApplicationId = TestApplicationId });
+    }
+
+    [Fact]
+    public async Task dafda_serialize_deserialize_new_kafka_topic_requested()
+    {
+        await dafda_serialize_deserialize(new NewKafkaTopicHasBeenRequested());
+        await dafda_serialize_deserialize(new NewKafkaTopicHasBeenRequested
+        {
+            CapabilityId = TestCapabilityId,
+            KafkaClusterId = TestKafkaClusterId,
+            KafkaTopicId = TestTopicId,
+            KafkaTopicName = TestTopicName
+        });
+    }
+
+    [Fact]
+    public async Task dafda_serialize_deserialize_new_membership_application_submitted()
+    {
+        await dafda_serialize_deserialize(new NewMembershipApplicationHasBeenSubmitted());
+        await dafda_serialize_deserialize(new NewMembershipApplicationHasBeenSubmitted
+        {
+            MembershipApplicationId = TestApplicationId
+        });
+    }
+
+    [Fact]
+    public async Task dafda_serialize_deserialize_new_message_contract_provisioned()
+    {
+        await dafda_serialize_deserialize(new NewMessageContractHasBeenProvisioned());
+        await dafda_serialize_deserialize(new NewMessageContractHasBeenProvisioned
+        {
+            KafkaTopicId = TestTopicId,
+            MessageContractId = TestMessageContractId,
+            MessageType = TestMessageType
+        });
+    }
+
+    [Fact]
+    public async Task dafda_serialize_deserialize_new_message_contract_requested()
+    {
+        await dafda_serialize_deserialize(new NewMessageContractHasBeenRequested());
+        await dafda_serialize_deserialize(new NewMessageContractHasBeenRequested
+        {
+            CapabilityId = TestCapabilityId,
+            Description = TestDescription,
+            KafkaClusterId = TestKafkaClusterId,
+            KafkaTopicId = TestTopicId,
+            KafkaTopicName = TestTopicName,
+            MessageContractId = TestMessageContractId,
+            MessageType = TestMessageType,
+            Schema = TestSchema,
+        });
+    }
+
+    [Fact]
+    public async Task dafda_serialize_deserialize_new_portal_visit_registered()
+    {
+        await dafda_serialize_deserialize(new NewPortalVisitRegistered());
+        await dafda_serialize_deserialize(new NewPortalVisitRegistered
+        {
+            PortalVisitId = TestPortalVisitId,
+            VisitedAt = "now",
+            VisitedBy = TestUser
+        });
+    }
+
+    [Fact]
+    public async Task dafda_serialize_deserialize_user_joined_capability()
+    {
+        await dafda_serialize_deserialize(new UserHasJoinedCapability());
+        await dafda_serialize_deserialize(new UserHasJoinedCapability
+        {
+            CapabilityId = TestCapabilityId,
+            MembershipId = TestMemberShipId
+        });
+    }
+
+    [Fact]
+    public async Task dafda_serialize_deserialize_user_left_capability()
+    {
+        await dafda_serialize_deserialize(new UserHasLeftCapability());
+        await dafda_serialize_deserialize(new UserHasLeftCapability
+        {
+            CapabilityId = TestCapabilityId,
+            MembershipId = TestMemberShipId,
+            UserId = TestUser
+        });
+    }
+}

--- a/src/SelfService/Domain/Events/KafkaClusterAccessGranted.cs
+++ b/src/SelfService/Domain/Events/KafkaClusterAccessGranted.cs
@@ -1,0 +1,9 @@
+using SelfService.Domain.Models;
+
+namespace SelfService.Domain.Events;
+
+public class KafkaClusterAccessGranted : IDomainEvent
+{
+    public string? CapabilityId { get; set; }
+    public string? KafkaClusterId { get; set; }
+}

--- a/src/SelfService/Domain/Events/KafkaTopicProvisioningHasBegun.cs
+++ b/src/SelfService/Domain/Events/KafkaTopicProvisioningHasBegun.cs
@@ -1,0 +1,10 @@
+using SelfService.Domain.Models;
+
+namespace SelfService.Domain.Events;
+
+public class KafkaTopicProvisioningHasBegun : IDomainEvent
+{
+    public string? ClusterId { get; set; }
+    public string? TopicId { get; set; }
+    public string? TopicName { get; set; }
+}

--- a/src/SelfService/Domain/Events/KafkaTopicProvisioningHasCompleted.cs
+++ b/src/SelfService/Domain/Events/KafkaTopicProvisioningHasCompleted.cs
@@ -1,0 +1,10 @@
+using SelfService.Domain.Models;
+
+namespace SelfService.Domain.Events;
+
+public class KafkaTopicProvisioningHasCompleted : IDomainEvent
+{
+    public string? ClusterId { get; set; }
+    public string? TopicId { get; set; }
+    public string? TopicName { get; set; }
+}

--- a/src/SelfService/Domain/Events/SchemaRegistered.cs
+++ b/src/SelfService/Domain/Events/SchemaRegistered.cs
@@ -1,0 +1,8 @@
+using SelfService.Domain.Models;
+
+namespace SelfService.Domain.Events;
+
+public class SchemaRegistered : IDomainEvent
+{
+    public string? MessageContractId { get; set; }
+}

--- a/src/SelfService/Domain/Policies/MarkMessageContractAsProvisioned.cs
+++ b/src/SelfService/Domain/Policies/MarkMessageContractAsProvisioned.cs
@@ -1,5 +1,6 @@
 ﻿using Dafda.Consuming;
 using SelfService.Application;
+using SelfService.Domain.Events;
 using SelfService.Domain.Exceptions;
 using SelfService.Domain.Models;
 
@@ -56,9 +57,4 @@ public class MarkMessageContractAsProvisioned : IMessageHandler<SchemaRegistered
             );
         }
     }
-}
-
-public class SchemaRegistered : IDomainEvent
-{
-    public string? MessageContractId { get; set; }
 }

--- a/src/SelfService/Infrastructure/Messaging/ConsumerConfiguration.cs
+++ b/src/SelfService/Infrastructure/Messaging/ConsumerConfiguration.cs
@@ -84,14 +84,7 @@ public static class ConsumerConfiguration
                     messageType: "membership-application-cancelled",
                     keySelector: x => x.MembershipApplicationId!
                 );
-
-            //options
-            //    .ForTopic($"{SelfServicePrefix}.portalvisit")
-            //    .Register<NewPortalVisitRegistered>(
-            //        messageType: "new-portal-visit-registered",
-            //        keySelector: x => x.VisitedBy!
-            //    )
-            //    ;
+            // NOTE: if adding new message types; add a test to SelfService.Tests/Infrastructure/Messaging/TestDafdaSerializationDeserialization.cs
         });
 
         builder.Services.AddConsumer(options =>
@@ -128,6 +121,7 @@ public static class ConsumerConfiguration
                 .RegisterMessageHandler<MembershipApplicationHasBeenCancelled, RemoveCancelledMembershipApplication>(
                     "membership-application-cancelled"
                 );
+            // NOTE: if adding new message types; add a test to SelfService.Tests/Infrastructure/Messaging/TestDafdaSerializationDeserialization.cs
 
             #region confluent gateway events
 
@@ -157,24 +151,10 @@ public static class ConsumerConfiguration
                 .RegisterMessageHandler<KafkaClusterAccessGranted, KafkaClusterAccessGrantedHandler>(
                     "cluster-access-granted"
                 );
-
+            // NOTE: if adding new message types; add a test to SelfService.Tests/Infrastructure/Messaging/TestDafdaSerializationDeserialization.cs"
             #endregion
         });
     }
-}
-
-public class KafkaTopicProvisioningHasBegun
-{
-    public string? ClusterId { get; set; }
-    public string? TopicId { get; set; }
-    public string? TopicName { get; set; }
-}
-
-public class KafkaTopicProvisioningHasCompleted
-{
-    public string? ClusterId { get; set; }
-    public string? TopicId { get; set; }
-    public string? TopicName { get; set; }
 }
 
 public class UpdateKafkaTopicProvisioningProgress
@@ -313,12 +293,6 @@ public class AwsAccountRequestedHandler : IMessageHandler<AwsAccountRequested>
 
         await _awsAccountApplicationService.CreateAwsAccountRequestTicket(id);
     }
-}
-
-public class KafkaClusterAccessGranted
-{
-    public string? CapabilityId { get; set; }
-    public string? KafkaClusterId { get; set; }
 }
 
 public class KafkaClusterAccessGrantedHandler : IMessageHandler<KafkaClusterAccessGranted>


### PR DESCRIPTION
closes dfds/cloudplatform/issues/1881

# Additional Review Notes
First I reverted the changes to AwsAccountRequested (#34) and then wrote the serialization+deserialization code that correctly replicated the error message seen in the bug. 
Then I added test for all domain events, both for using the parameterless constructor and constructor with parameters.

I also extracted some classes into the directory where the other DomainEvents are.
