### PR TITLE
Fix/1933 allow multiple topdesk ticket types

### DIFF
--- a/fake_dependencies/confluent-gateway/FakeConfluentGateway.App/Program.cs
+++ b/fake_dependencies/confluent-gateway/FakeConfluentGateway.App/Program.cs
@@ -46,7 +46,8 @@ app.MapPost(
             return Results.Ok();
         }
 
-        if (headers["TICKET_TYPE"] == TopdeskTicketType.awsAccountRequest) {
+        if (headers["TICKET_TYPE"] == TopdeskTicketType.awsAccountRequest)
+        {
             var legacyProducer = context.RequestServices.GetRequiredService<LegacyProducer>();
             var contextId = headers["CONTEXT_ID"];
             var accountId = RandomAccountId(12);

--- a/fake_dependencies/confluent-gateway/FakeConfluentGateway.App/Program.cs
+++ b/fake_dependencies/confluent-gateway/FakeConfluentGateway.App/Program.cs
@@ -46,7 +46,7 @@ app.MapPost(
             return Results.Ok();
         }
 
-        if (headers["TICKET_TYPE"] == TopdeskTicketType.awsAccountRequest)
+        if (headers["TICKET_TYPE"] == TopdeskTicketType.AwsAccountRequest)
         {
             var legacyProducer = context.RequestServices.GetRequiredService<LegacyProducer>();
             var contextId = headers["CONTEXT_ID"];

--- a/src/SelfService.Tests/Application/TestAwsAccountApplicationService.cs
+++ b/src/SelfService.Tests/Application/TestAwsAccountApplicationService.cs
@@ -65,6 +65,7 @@ public class TestAwsAccountApplicationService
         Assert.Equal(
             new Dictionary<string, string>
             {
+                ["TICKET_TYPE"] = TopdeskTicketType.awsAccountRequest,
                 ["CORRELATION_ID"] = "",
                 ["CAPABILITY_NAME"] = capability.Name,
                 ["CAPABILITY_ID"] = capability.Id,

--- a/src/SelfService.Tests/Application/TestAwsAccountApplicationService.cs
+++ b/src/SelfService.Tests/Application/TestAwsAccountApplicationService.cs
@@ -65,7 +65,7 @@ public class TestAwsAccountApplicationService
         Assert.Equal(
             new Dictionary<string, string>
             {
-                ["TICKET_TYPE"] = TopdeskTicketType.awsAccountRequest,
+                ["TICKET_TYPE"] = TopdeskTicketType.AwsAccountRequest,
                 ["CORRELATION_ID"] = "",
                 ["CAPABILITY_NAME"] = capability.Name,
                 ["CAPABILITY_ID"] = capability.Id,

--- a/src/SelfService.Tests/Builders/CapabilityBuilder.cs
+++ b/src/SelfService.Tests/Builders/CapabilityBuilder.cs
@@ -34,11 +34,13 @@ public class CapabilityBuilder
         _name = name;
         return this;
     }
+
     public CapabilityBuilder WithModifiedAt(DateTime modifiedAt)
     {
         _modifiedAt = modifiedAt;
         return this;
     }
+
     public CapabilityBuilder WithDescription(string description)
     {
         _description = description;

--- a/src/SelfService.Tests/Comparers/CapabilityComparer.cs
+++ b/src/SelfService.Tests/Comparers/CapabilityComparer.cs
@@ -38,7 +38,16 @@ public class CapabilityComparer : IEqualityComparer<Capability?>
 
     public int GetHashCode(Capability obj)
     {
-        return HashCode.Combine(obj.Id, obj.Name, obj.Description, obj.Status, obj.CreatedAt, obj.ModifiedAt, obj.CreatedBy, obj.ModifiedBy);
+        return HashCode.Combine(
+            obj.Id,
+            obj.Name,
+            obj.Description,
+            obj.Status,
+            obj.CreatedAt,
+            obj.ModifiedAt,
+            obj.CreatedBy,
+            obj.ModifiedBy
+        );
     }
 }
 

--- a/src/SelfService.Tests/Infrastructure/Persistence/TestCapabilityRepository.cs
+++ b/src/SelfService.Tests/Infrastructure/Persistence/TestCapabilityRepository.cs
@@ -34,15 +34,14 @@ public class TestCapabilityRepository
         var repo = A.CapabilityRepository.WithDbContext(dbContext).Build();
 
         await repo.Add(A.Capability.WithId("active"));
-        await repo.Add(A.Capability.WithId("pending-new")
-            .WithStatus(CapabilityStatusOptions.PendingDeletion));
-        await repo.Add(A.Capability.WithId("pending-old")
-            .WithStatus(CapabilityStatusOptions.PendingDeletion)
-            .WithModifiedAt(DateTime.UtcNow.AddDays(-8))
+        await repo.Add(A.Capability.WithId("pending-new").WithStatus(CapabilityStatusOptions.PendingDeletion));
+        await repo.Add(
+            A.Capability
+                .WithId("pending-old")
+                .WithStatus(CapabilityStatusOptions.PendingDeletion)
+                .WithModifiedAt(DateTime.UtcNow.AddDays(-8))
         );
-        await repo.Add(A.Capability.WithId("deleted")
-            .WithStatus(CapabilityStatusOptions.Deleted)
-        );
+        await repo.Add(A.Capability.WithId("deleted").WithStatus(CapabilityStatusOptions.Deleted));
 
         await dbContext.SaveChangesAsync();
 

--- a/src/SelfService/Application/AwsAccountApplicationService.cs
+++ b/src/SelfService/Application/AwsAccountApplicationService.cs
@@ -73,7 +73,7 @@ public class AwsAccountApplicationService : IAwsAccountApplicationService
 
         if (_environment.IsDevelopment())
         {
-            headers["TICKET_TYPE"] = TopdeskTicketType.awsAccountRequest;
+            headers["TICKET_TYPE"] = TopdeskTicketType.AwsAccountRequest;
             headers["CORRELATION_ID"] = "";
             headers["CAPABILITY_NAME"] = capability.Name;
             headers["CAPABILITY_ID"] = capability.Id;

--- a/src/SelfService/Application/AwsAccountApplicationService.cs
+++ b/src/SelfService/Application/AwsAccountApplicationService.cs
@@ -73,6 +73,7 @@ public class AwsAccountApplicationService : IAwsAccountApplicationService
 
         if (_environment.IsDevelopment())
         {
+            headers["TICKET_TYPE"] = TopdeskTicketType.awsAccountRequest;
             headers["CORRELATION_ID"] = "";
             headers["CAPABILITY_NAME"] = capability.Name;
             headers["CAPABILITY_ID"] = capability.Id;

--- a/src/SelfService/Application/CapabilityApplicationService.cs
+++ b/src/SelfService/Application/CapabilityApplicationService.cs
@@ -204,6 +204,7 @@ public class CapabilityApplicationService : ICapabilityApplicationService
             var message = sb.ToString();
 
             var headers = new Dictionary<string, string>();
+            headers["TICKET_TYPE"] = TopdeskTicketType.capabilityDeletionRequest;
             headers["CAPABILITY_NAME"] = capability.Name;
             headers["CAPABILITY_ID"] = capability.Id;
             headers["CAPABILITY_CREATED_BY"] = capability.CreatedBy;

--- a/src/SelfService/Application/CapabilityApplicationService.cs
+++ b/src/SelfService/Application/CapabilityApplicationService.cs
@@ -196,11 +196,17 @@ public class CapabilityApplicationService : ICapabilityApplicationService
         {
             var sb = new StringBuilder();
             sb.AppendLine("*Capability Deletion Request*");
-            sb.AppendLine("The following capability has been pending deletion for 7 days and will be deleted in 24 hours:");
-            sb.AppendFormat("Capability Name: {0}", capability.Name); sb.AppendLine();
-            sb.AppendFormat("Capability Id: {0}", capability.Id); sb.AppendLine();
-            sb.AppendFormat("Deletion Requested by user: {0}", capability.ModifiedBy); sb.AppendLine();
-            sb.AppendFormat("Originally Created by user: {0}", capability.CreatedBy); sb.AppendLine();
+            sb.AppendLine(
+                "The following capability has been pending deletion for 7 days and will be deleted in 24 hours:"
+            );
+            sb.AppendFormat("Capability Name: {0}", capability.Name);
+            sb.AppendLine();
+            sb.AppendFormat("Capability Id: {0}", capability.Id);
+            sb.AppendLine();
+            sb.AppendFormat("Deletion Requested by user: {0}", capability.ModifiedBy);
+            sb.AppendLine();
+            sb.AppendFormat("Originally Created by user: {0}", capability.CreatedBy);
+            sb.AppendLine();
             var message = sb.ToString();
 
             var headers = new Dictionary<string, string>();

--- a/src/SelfService/Application/CapabilityApplicationService.cs
+++ b/src/SelfService/Application/CapabilityApplicationService.cs
@@ -210,7 +210,7 @@ public class CapabilityApplicationService : ICapabilityApplicationService
             var message = sb.ToString();
 
             var headers = new Dictionary<string, string>();
-            headers["TICKET_TYPE"] = TopdeskTicketType.capabilityDeletionRequest;
+            headers["TICKET_TYPE"] = TopdeskTicketType.CapabilityDeletionRequest;
             headers["CAPABILITY_NAME"] = capability.Name;
             headers["CAPABILITY_ID"] = capability.Id;
             headers["CAPABILITY_CREATED_BY"] = capability.CreatedBy;

--- a/src/SelfService/Domain/Models/Capability.cs
+++ b/src/SelfService/Domain/Models/Capability.cs
@@ -71,7 +71,8 @@ public class Capability : AggregateRoot<CapabilityId>
         ModifiedBy = userId;
     }
 
-    public void MarkAsDeleted() {
+    public void MarkAsDeleted()
+    {
         if (Status != CapabilityStatusOptions.PendingDeletion)
         {
             throw new InvalidOperationException("Capability is not pending deletion");

--- a/src/SelfService/Domain/Models/TopdeskTicketTypes.cs
+++ b/src/SelfService/Domain/Models/TopdeskTicketTypes.cs
@@ -2,24 +2,24 @@ namespace SelfService.Domain.Models;
 
 public class TopdeskTicketType : ValueObject
 {
-    public static readonly TopdeskTicketType awsAccountRequest = new("AWS_ACCOUNT_REQUEST");
-    public static readonly TopdeskTicketType capabilityDeletionRequest = new("CAPABILITY_DELETION_REQUEST");
+    public static readonly TopdeskTicketType AwsAccountRequest = new("AWS_ACCOUNT_REQUEST");
+    public static readonly TopdeskTicketType CapabilityDeletionRequest = new("CAPABILITY_DELETION_REQUEST");
 
-    protected TopdeskTicketType(string type)
+    private TopdeskTicketType(string type)
     {
-        Type = type;
+        _value = type;
     }
 
-    public string Type { get; private set; }
+    public string _value { get; private set; }
 
     protected override IEnumerable<object> GetEqualityComponents()
     {
-        yield return Type!;
+        yield return _value;
     }
 
     public override string ToString()
     {
-        return Type;
+        return _value;
     }
 
     public static implicit operator string(TopdeskTicketType type) => type.ToString();

--- a/src/SelfService/Domain/Models/TopdeskTicketTypes.cs
+++ b/src/SelfService/Domain/Models/TopdeskTicketTypes.cs
@@ -1,0 +1,25 @@
+namespace SelfService.Domain.Models;
+
+public class TopdeskTicketType : ValueObject
+{
+    public static readonly TopdeskTicketType awsAccountRequest = new("AWS_ACCOUNT_REQUEST");
+    public static readonly TopdeskTicketType capabilityDeletionRequest = new("CAPABILITY_DELETION_REQUEST");
+
+    protected TopdeskTicketType(string type) {
+        Type = type;
+    }
+
+    public string Type { get; private set; }
+    
+    protected override IEnumerable<object> GetEqualityComponents()
+    {
+        yield return Type!;
+    }
+
+    public override string ToString()
+    {
+        return Type;
+    }
+
+    public static implicit operator string(TopdeskTicketType type) => type.ToString();
+}

--- a/src/SelfService/Domain/Models/TopdeskTicketTypes.cs
+++ b/src/SelfService/Domain/Models/TopdeskTicketTypes.cs
@@ -10,7 +10,7 @@ public class TopdeskTicketType : ValueObject
         _value = type;
     }
 
-    public string _value { get; private set; }
+    private readonly string _value;
 
     protected override IEnumerable<object> GetEqualityComponents()
     {

--- a/src/SelfService/Domain/Models/TopdeskTicketTypes.cs
+++ b/src/SelfService/Domain/Models/TopdeskTicketTypes.cs
@@ -5,12 +5,13 @@ public class TopdeskTicketType : ValueObject
     public static readonly TopdeskTicketType awsAccountRequest = new("AWS_ACCOUNT_REQUEST");
     public static readonly TopdeskTicketType capabilityDeletionRequest = new("CAPABILITY_DELETION_REQUEST");
 
-    protected TopdeskTicketType(string type) {
+    protected TopdeskTicketType(string type)
+    {
         Type = type;
     }
 
     public string Type { get; private set; }
-    
+
     protected override IEnumerable<object> GetEqualityComponents()
     {
         yield return Type!;


### PR DESCRIPTION
closes dfds/cloudplatform/issues/1933

# Additional Review Notes
 Created a new ticket type and updated our Fake Confluent Gateway.
 
 The current Fake Confluent Gateway caused a bug, as it assumed the existence of only one Topdesk Ticket ever being present in the system. Thus it chose to add additional functionality to certain calls.
 This call to /sendnotification does not even belong to the Fake Confluent Gateway, but I have left that cleanup for later. We have to revisit our fakes anyway.
 
 This bug is not present in production, as the issue is the way we mock things locally.
