### PR TITLE
remove null values in capabilities modifiedBy

### DIFF
--- a/db/migrations/20230824105400_set-modified-by-to-some-value.sql
+++ b/db/migrations/20230824105400_set-modified-by-to-some-value.sql
@@ -1,0 +1,5 @@
+-- 2023-08-24 10:54:xx : Make sure ModifiedBy is not null
+
+UPDATE "Capability"
+SET "ModifiedBy" = "CreatedBy"
+WHERE "ModifiedBy" IS NULL;


### PR DESCRIPTION
closes dfds/cloudplatform/issues/1946

# Additional Review Notes
Null is not allowed, yet we set it as a default for existing entries.
Let's fill it with a meaningful value