### PR TITLE
Fixed crash in MemberShipCleaner service

### DIFF
--- a/src/SelfService.Tests/TestDoubles/StubUserStatusChecker.cs
+++ b/src/SelfService.Tests/TestDoubles/StubUserStatusChecker.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.Logging;
+using SelfService.Domain.Models;
 using SelfService.Infrastructure.BackgroundJobs;
 
 namespace SelfService.Tests.TestDoubles;
@@ -13,6 +14,11 @@ public class StubUserStatusChecker : IUserStatusChecker
         SetAuthToken();
     }
 
+    public bool TrySetAuthToken()
+    {
+        return false;
+    }
+
     private void SetAuthToken()
     {
         return; //so we can await it
@@ -23,15 +29,15 @@ public class StubUserStatusChecker : IUserStatusChecker
         return new Task<bool>(() => true);
     }
 
-    public async Task<(bool, string)> CheckUserStatus(string userId)
+    public async Task<UserStatusCheckerStatus> CheckUserStatus(string userId)
     {
         await BusyWait();
         if (userId == "userdeactivated@dfds.com")
-            return new(true, "Deactivated");
+            return UserStatusCheckerStatus.Deactivated;
 
         if (userId == "useractive@dfds.com")
-            return (false, "");
+            return UserStatusCheckerStatus.Found;
 
-        return (true, "NotFound"); //undefined for this test
+        return UserStatusCheckerStatus.NotFound; //undefined for this test
     }
 }

--- a/src/SelfService/Application/DeactivatedMemberCleanerApplicationService.cs
+++ b/src/SelfService/Application/DeactivatedMemberCleanerApplicationService.cs
@@ -12,6 +12,8 @@ public class DeactivatedMemberCleanerApplicationService
 
     private readonly ILogger<DeactivatedMemberCleanerApplicationService> _logger;
 
+    private readonly StringBuilder _sb = new();
+
     public DeactivatedMemberCleanerApplicationService(
         ILogger<DeactivatedMemberCleanerApplicationService> logger,
         IMembershipRepository membershipRepository,
@@ -25,57 +27,78 @@ public class DeactivatedMemberCleanerApplicationService
         _logger = logger;
     }
 
+    private string ToIdStringList(List<Member> members)
+    {
+        _sb.Clear();
+
+        foreach (var notFoundMember in members)
+        {
+            _sb.AppendLine(notFoundMember.Id);
+        }
+
+        return _sb.ToString();
+    }
+
     public async Task RemoveDeactivatedMemberships(IUserStatusChecker userStatusChecker)
     {
         _logger.LogDebug("Started looking for deactivated users");
+        if (!userStatusChecker.TrySetAuthToken())
+        {
+            _logger.LogError("Unable to Remove Deactivated Memberships, no valid auth token found");
+            return;
+        }
+
         var members = await _memberRepository.GetAll();
         List<Member> deactivatedMembers = new List<Member>();
         List<Member> notFoundMembers = new List<Member>();
-        StringBuilder deactivatedMembersStringBuilder = new StringBuilder();
-        StringBuilder notFoundMembersStringBuilder = new StringBuilder();
         foreach (var member in members)
         {
-            var (isDeactivated, reason) = await userStatusChecker.CheckUserStatus(member.Id);
-            if (isDeactivated)
+            var status = await userStatusChecker.CheckUserStatus(member.Id);
+
+            if (status == UserStatusCheckerStatus.NotFound)
+                notFoundMembers.Add(member);
+            if (status == UserStatusCheckerStatus.Deactivated)
+                deactivatedMembers.Add(member);
+
+            if (status == UserStatusCheckerStatus.NoAuthToken || status == UserStatusCheckerStatus.BadAuthToken)
             {
-                if (reason == "NotFound")
-                {
-                    notFoundMembers.Add(member);
-                    notFoundMembersStringBuilder.AppendLine(member.Id);
-                }
-                if (reason == "Deactivated")
-                {
-                    deactivatedMembers.Add(member);
-                    deactivatedMembersStringBuilder.AppendLine(member.Id);
-                }
+                _logger.LogError("Unable to check status of user {UserID}, no valid auth token found", member.Id);
+                return;
             }
         }
+
         if (notFoundMembers.Count <= 0)
         {
             _logger.LogDebug("no users were completely unfound in Azure AD (yay)");
         }
+        else
+        {
+            _logger.LogWarning(
+                "[TRIAL] following {NotFoundmembersCount} members not found in Azure AD:\n{notfoundMembers}\n NOT deleting for now",
+                notFoundMembers.Count,
+                ToIdStringList(notFoundMembers)
+            );
+        }
+
         if (deactivatedMembers.Count <= 0)
         {
             _logger.LogDebug("Found no members with deactivated/disabled accounts");
         }
+        else
+        {
+            _logger.LogDebug(
+                "Removing {DeactivatedMembersCount} members, disabled or not found in Azure AD:\\n{DeactivatedMembers}",
+                deactivatedMembers.Count,
+                ToIdStringList(deactivatedMembers)
+            );
+        }
 
-        _logger.LogWarning(
-            "[TRIAL] following {NotFoundmembersCount} members not found in Azure AD:\n{notfoundMembers}\n NOT deleting for now",
-            notFoundMembers.Count,
-            notFoundMembersStringBuilder.ToString()
-        );
+        var membersToBeDeleted = new HashSet<Member>();
+        deactivatedMembers.ForEach(x => membersToBeDeleted.Add(x));
+        //notFoundMembers.ForEach(x => membersToBeDeleted.Add(x)); // TODO: Enable when we deem it safe
 
-        _logger.LogDebug(
-            "Removing {DeactivatedMembersCount} members, disabled or not found in Azure AD:\\n{DeactivatedMembers}",
-            deactivatedMembers.Count,
-            deactivatedMembersStringBuilder.ToString()
-        );
-
-        List<Member> membersToBeDeleted = deactivatedMembers;
-
-        // membersToBeDeleted = deactivatedMembers
-        //     .Concat(notFoundMembers)
-        //     .ToHashSet().ToList(); //removal of duplicates if an Id is in both lists, though this shouldn't happen
+        if (membersToBeDeleted.Count <= 0)
+            return;
 
         foreach (var member in membersToBeDeleted)
         {

--- a/src/SelfService/Domain/Models/UserStatusCheckerStatus.cs
+++ b/src/SelfService/Domain/Models/UserStatusCheckerStatus.cs
@@ -1,0 +1,52 @@
+namespace SelfService.Domain.Models;
+
+public class UserStatusCheckerStatus : ValueObject
+{
+    public static readonly UserStatusCheckerStatus Deactivated = new("Deactivated");
+    public static readonly UserStatusCheckerStatus Found = new("Found");
+    public static readonly UserStatusCheckerStatus NotFound = new("NotFound");
+    public static readonly UserStatusCheckerStatus NoAuthToken = new("NoAuthToken");
+    public static readonly UserStatusCheckerStatus BadAuthToken = new("BadAuthToken");
+    public static readonly UserStatusCheckerStatus Unknown = new("Unknown");
+
+    private readonly string _value;
+
+    private static readonly Dictionary<string, UserStatusCheckerStatus> UserStatusMap =
+        new()
+        {
+            { Deactivated.ToString(), Deactivated },
+            { Found.ToString(), Found },
+            { NotFound.ToString(), NotFound },
+            { NoAuthToken.ToString(), NoAuthToken },
+            { BadAuthToken.ToString(), BadAuthToken },
+            { Unknown.ToString(), Unknown }
+        };
+
+    private UserStatusCheckerStatus(string status)
+    {
+        _value = status;
+    }
+
+    protected override IEnumerable<object> GetEqualityComponents()
+    {
+        yield return _value;
+    }
+
+    public override string ToString()
+    {
+        return _value;
+    }
+
+    public static bool TryParse(string? text, out UserStatusCheckerStatus role)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            role = null!;
+            return false;
+        }
+
+        bool success = UserStatusMap.TryGetValue(text, out var mappedRole);
+        role = success ? mappedRole! : null!;
+        return success;
+    }
+}

--- a/src/SelfService/Infrastructure/BackgroundJobs/IUserStatusChecker.cs
+++ b/src/SelfService/Infrastructure/BackgroundJobs/IUserStatusChecker.cs
@@ -1,8 +1,10 @@
 using System.Threading.Tasks;
+using SelfService.Domain.Models;
 
 namespace SelfService.Infrastructure.BackgroundJobs;
 
 public interface IUserStatusChecker
 {
-    Task<(bool, string)> CheckUserStatus(string userId);
+    Task<UserStatusCheckerStatus> CheckUserStatus(string userId);
+    bool TrySetAuthToken();
 }


### PR DESCRIPTION
closes dfds/cloudplatform/issues/1971

# Additional Review Notes
Code now can handle missing or bad auth token without crashing the api

Also contains some refactoring:
- Getting rid of string value representing status
- 
