### PR TITLE
Simplest change to allow privileged users access to deleted capabilities

### DIFF
--- a/db/seed/Capability.csv
+++ b/db/seed/Capability.csv
@@ -1,5 +1,10 @@
 Id;Name;Description;CreatedAt;CreatedBy;Status;ModifiedAt,ModifiedBy
-cloudengineering-xxx;CloudEngineering-xxx;This is cloud stuff;2023-02-10T08:00:00;SeedScript;Active;2023-02-10T08:00:00;SeedScript
+cloudengineering-xxx;CloudEngineering;This is cloud stuff;2023-02-10T08:00:00;SeedScript;Active;2023-02-10T08:00:00;SeedScript
 marketing-department-xxx;Marketing-Department;We send emails;2023-02-10T08:00:00;SeedScript;Deleted;2023-07-25T08:00:00;SeedScript
-pending-deletion-xxx;pending-deletion-xxx;Pending Deletion;2023-02-10T08:00:00;SeedScript;Pending Deletion;2023-02-10T08:00:00;SeedScript
 cool-beans-xxx;Cool-beans-xxx;Only Bean enthusiasts;2023-02-10T08:00:00;SeedScript;Active;2023-02-10T08:00:00;SeedScript
+pending-deletion-xxx;pending-deletion;Pending Deletion;2023-02-10T08:00:00;SeedScript;Pending Deletion;2023-02-10T08:00:00;SeedScript
+notmycapability-xx1;Not My Capability 1;Something you are not a member of;2023-02-10T08:00:00;SeedScript;Active;2023-02-10T08:00:00;SeedScript
+notmycapability-xx2;Not My Capability 2;Something you are not a member of;2023-02-10T08:00:00;SeedScript;Active;2023-02-10T08:00:00;SeedScript
+notmycapability-xx3;Not My Capability 3;Something you are not a member of;2023-02-10T08:00:00;SeedScript;Active;2023-02-10T08:00:00;SeedScript
+notmycapability-xx4;Not My Capability 4;Something you are not a member of;2023-02-10T08:00:00;SeedScript;Active;2023-02-10T08:00:00;SeedScript
+notmycapability-xx5;Not My Capability 5;Something you are not a member of;2023-02-10T08:00:00;SeedScript;Active;2023-02-10T08:00:00;SeedScript

--- a/src/SelfService.Tests/Infrastructure/Persistence/TestCapabilityRepository.cs
+++ b/src/SelfService.Tests/Infrastructure/Persistence/TestCapabilityRepository.cs
@@ -48,7 +48,7 @@ public class TestCapabilityRepository
         var allCapabilities = await repo.GetAll(); // does not get deleted
         var readyForDeletion = await repo.GetAllPendingDeletionFor(days: 7);
 
-        Assert.Equal(3, allCapabilities.Count());
+        Assert.Equal(4, allCapabilities.Count());
         Assert.Single(readyForDeletion);
         Assert.Equal("pending-old", readyForDeletion.First().Id);
     }

--- a/src/SelfService/Domain/Services/AuthorizationService.cs
+++ b/src/SelfService/Domain/Services/AuthorizationService.cs
@@ -58,6 +58,15 @@ public class AuthorizationService : IAuthorizationService
         return true;
     }
 
+    public bool CanViewDeletedCapabilities(PortalUser portalUser)
+    {
+        if (portalUser.Roles.Any(role => role == UserRole.CloudEngineer))
+        {
+            return true;
+        }
+        return false;
+    }
+
     public async Task<bool> CanDelete(PortalUser portalUser, KafkaTopic kafkaTopic)
     {
         if (kafkaTopic.IsPublic)

--- a/src/SelfService/Domain/Services/IAuthorizationService.cs
+++ b/src/SelfService/Domain/Services/IAuthorizationService.cs
@@ -23,4 +23,5 @@ public interface IAuthorizationService
     Task<bool> CanApply(UserId userId, CapabilityId capabilityId);
     Task<bool> CanViewAllApplications(UserId userId, CapabilityId capabilityId);
     Task<bool> CanDeleteCapability(UserId userId, CapabilityId capabilityId);
+    bool CanViewDeletedCapabilities(PortalUser portalUser);
 }

--- a/src/SelfService/Infrastructure/Api/ApiResourceFactory.cs
+++ b/src/SelfService/Infrastructure/Api/ApiResourceFactory.cs
@@ -174,6 +174,17 @@ public class ApiResourceFactory
 
     public CapabilityListApiResource Convert(IEnumerable<Capability> capabilities)
     {
+        var includeDeleted = false;
+        if (_authorizationService.CanViewDeletedCapabilities(PortalUser))
+        {
+            includeDeleted = true;
+        }
+
+        if (!includeDeleted)
+        {
+            capabilities = capabilities.Where(x => x.Status != CapabilityStatusOptions.Deleted);
+        }
+
         return new CapabilityListApiResource(
             items: capabilities.Select(ConvertToListItem).ToArray(),
             links: new CapabilityListApiResource.CapabilityListLinks(

--- a/src/SelfService/Infrastructure/Api/ApiResourceFactory.cs
+++ b/src/SelfService/Infrastructure/Api/ApiResourceFactory.cs
@@ -174,16 +174,8 @@ public class ApiResourceFactory
 
     public CapabilityListApiResource Convert(IEnumerable<Capability> capabilities)
     {
-        var includeDeleted = false;
-        if (_authorizationService.CanViewDeletedCapabilities(PortalUser))
-        {
-            includeDeleted = true;
-        }
-
-        if (!includeDeleted)
-        {
-            capabilities = capabilities.Where(x => x.Status != CapabilityStatusOptions.Deleted);
-        }
+        var showDeleted = _authorizationService.CanViewDeletedCapabilities(PortalUser);
+            capabilities = showDeleted? capabilities : capabilities.Where(x => x.Status != CapabilityStatusOptions.Deleted);
 
         return new CapabilityListApiResource(
             items: capabilities.Select(ConvertToListItem).ToArray(),

--- a/src/SelfService/Infrastructure/Persistence/CapabilityRepository.cs
+++ b/src/SelfService/Infrastructure/Persistence/CapabilityRepository.cs
@@ -41,10 +41,7 @@ public class CapabilityRepository : ICapabilityRepository
 
     public async Task<IEnumerable<Capability>> GetAll()
     {
-        return await _dbContext.Capabilities
-            .Where(c => c.Status != CapabilityStatusOptions.Deleted)
-            .OrderBy(x => x.Name)
-            .ToListAsync();
+        return await _dbContext.Capabilities.OrderBy(x => x.Name).ToListAsync();
     }
 
     public async Task<IEnumerable<Capability>> GetAllPendingDeletionFor(int days)


### PR DESCRIPTION
closes dfds/cloudplatform/issues/1955

# Additional Review Notes
I do not believe that this is the best way to do this;
It is very specific and not easily expandable should we add more states or roles.

However, it _is_ a simple way to do this, following our existing patterns and approaches.

I am all ears for equally simple but better ways of doing this.

We can also move this to the frontend, but I believe it belongs here.
Lastly; Changing this in this way will not impact our current users.
