### PR TITLE
Added background service that synchronizes aws and db ECR repositories

### DIFF
--- a/src/SelfService.Tests/Infrastructure/Persistence/TestECRRepositoryRepository.cs
+++ b/src/SelfService.Tests/Infrastructure/Persistence/TestECRRepositoryRepository.cs
@@ -67,7 +67,7 @@ public class TestECRRepositoryRepository
         await sut.Add(repositoryToNotBeDeleted);
         await dbContext.SaveChangesAsync();
 
-        await sut.RemoveWithRepositoryName(toBeDeletedRepositoryName);
+        sut.RemoveRangeWithRepositoryName(new List<string> { toBeDeletedRepositoryName });
 
         var repositories = await dbContext.ECRRepositories.ToListAsync();
         Assert.Single(repositories);

--- a/src/SelfService.Tests/Infrastructure/Persistence/TestECRRepositoryRepository.cs
+++ b/src/SelfService.Tests/Infrastructure/Persistence/TestECRRepositoryRepository.cs
@@ -39,12 +39,11 @@ public class TestECRRepositoryRepository
 
         var sut = A.ECRRepositoryRepository.WithDbContext(dbContext).Build();
 
-        sut.Add(repositoryToBeDeleted);
-        sut.Add(repositoryToNotBeDeleted);
+        await sut.Add(repositoryToBeDeleted);
+        await sut.Add(repositoryToNotBeDeleted);
         await dbContext.SaveChangesAsync();
 
         await sut.RemoveWithRepositoryName(toBeDeletedRepositoryName);
-        await dbContext.SaveChangesAsync();
 
         var repositories = await dbContext.ECRRepositories.ToListAsync();
         Assert.Single(repositories);

--- a/src/SelfService.Tests/Infrastructure/Persistence/TestECRRepositoryRepository.cs
+++ b/src/SelfService.Tests/Infrastructure/Persistence/TestECRRepositoryRepository.cs
@@ -16,7 +16,7 @@ public class TestECRRepositoryRepository
 
         var sut = A.ECRRepositoryRepository.WithDbContext(dbContext).Build();
 
-        sut.Add(stub);
+        await sut.Add(stub);
 
         await dbContext.SaveChangesAsync();
 

--- a/src/SelfService.Tests/Infrastructure/Persistence/TestECRRepositoryRepository.cs
+++ b/src/SelfService.Tests/Infrastructure/Persistence/TestECRRepositoryRepository.cs
@@ -26,6 +26,30 @@ public class TestECRRepositoryRepository
 
     [Fact]
     [Trait("Category", "InMemoryDatabase")]
+    public async Task add_range_inserts_expected_ecr_repositories_into_database()
+    {
+        await using var databaseFactory = new InMemoryDatabaseFactory();
+        var dbContext = await databaseFactory.CreateDbContext();
+
+        var stubs = new List<ECRRepository>()
+        {
+            A.ECRRepository.WithRepositoryName("first stub").Build(),
+            A.ECRRepository.WithRepositoryName("second stub").Build()
+        };
+        var sut = A.ECRRepositoryRepository.WithDbContext(dbContext).Build();
+
+        await sut.AddRange(stubs);
+
+        await dbContext.SaveChangesAsync();
+
+        var inserted = await dbContext.ECRRepositories.ToListAsync();
+        Assert.Equal(2, inserted.Count);
+        Assert.True(ECRRepositoriesAreEqual(stubs[0], inserted[0]));
+        Assert.True(ECRRepositoriesAreEqual(stubs[1], inserted[1]));
+    }
+
+    [Fact]
+    [Trait("Category", "InMemoryDatabase")]
     public async Task remove_with_repository_name_removes_expected_ecr_repository_from_database()
     {
         const string toBeDeletedRepositoryName = "to be deleted";

--- a/src/SelfService.Tests/Infrastructure/Persistence/TestECRRepositoryRepository.cs
+++ b/src/SelfService.Tests/Infrastructure/Persistence/TestECRRepositoryRepository.cs
@@ -43,6 +43,7 @@ public class TestECRRepositoryRepository
         await dbContext.SaveChangesAsync();
 
         var inserted = await dbContext.ECRRepositories.ToListAsync();
+        inserted.Sort((x, y) => string.Compare(x.RepositoryName, y.RepositoryName, StringComparison.Ordinal));
         Assert.Equal(2, inserted.Count);
         Assert.True(ECRRepositoriesAreEqual(stubs[0], inserted[0]));
         Assert.True(ECRRepositoriesAreEqual(stubs[1], inserted[1]));

--- a/src/SelfService.Tests/Infrastructure/Persistence/TestECRRepositoryRepository.cs
+++ b/src/SelfService.Tests/Infrastructure/Persistence/TestECRRepositoryRepository.cs
@@ -68,6 +68,7 @@ public class TestECRRepositoryRepository
         await dbContext.SaveChangesAsync();
 
         sut.RemoveRangeWithRepositoryName(new List<string> { toBeDeletedRepositoryName });
+        await dbContext.SaveChangesAsync();
 
         var repositories = await dbContext.ECRRepositories.ToListAsync();
         Assert.Single(repositories);

--- a/src/SelfService/Configuration/Domain.cs
+++ b/src/SelfService/Configuration/Domain.cs
@@ -73,6 +73,7 @@ public static class Domain
         builder.Services.AddHostedService<RemoveDeactivatedMemberships>();
         builder.Services.AddHostedService<PortalVisitAnalyzer>();
         builder.Services.AddHostedService<ActOnPendingCapabilityDeletions>();
+        builder.Services.AddHostedService<ECRRepositorySynchronizer>();
 
         // misc
         builder.Services.AddTransient<IDbTransactionFacade, RealDbTransactionFacade>();

--- a/src/SelfService/Domain/Models/IECRRepositoryRepository.cs
+++ b/src/SelfService/Domain/Models/IECRRepositoryRepository.cs
@@ -5,5 +5,5 @@ public interface IECRRepositoryRepository
     Task<IEnumerable<ECRRepository>> GetAll();
     Task Add(ECRRepository ecrRepository);
     Task AddRange(List<ECRRepository> ecrRepositories);
-    Task RemoveWithRepositoryName(string repositoryName);
+    void RemoveRangeWithRepositoryName(List<string> repositoryNames);
 }

--- a/src/SelfService/Domain/Models/IECRRepositoryRepository.cs
+++ b/src/SelfService/Domain/Models/IECRRepositoryRepository.cs
@@ -3,6 +3,7 @@ namespace SelfService.Domain.Models;
 public interface IECRRepositoryRepository
 {
     Task<IEnumerable<ECRRepository>> GetAll();
-    void Add(ECRRepository ecr);
+    Task Add(ECRRepository ecrRepository);
+    Task AddRange(List<ECRRepository> ecrRepositories);
     Task RemoveWithRepositoryName(string repositoryName);
 }

--- a/src/SelfService/Domain/Services/AuthorizationService.cs
+++ b/src/SelfService/Domain/Services/AuthorizationService.cs
@@ -181,4 +181,9 @@ public class AuthorizationService : IAuthorizationService
     {
         return await _membershipQuery.HasActiveMembership(userId, capabilityId);
     }
+
+    public bool CanSynchronizeAwsECRAndDatabaseECR(PortalUser portalUser)
+    {
+        return portalUser.Roles.Any(role => role == UserRole.CloudEngineer);
+    }
 }

--- a/src/SelfService/Domain/Services/ECRRepositoryService.cs
+++ b/src/SelfService/Domain/Services/ECRRepositoryService.cs
@@ -9,8 +9,6 @@ public class ECRRepositoryService : IECRRepositoryService
     private readonly IECRRepositoryRepository _ecrRepositoryRepository;
     private readonly IAwsECRRepositoryApplicationService _awsEcrRepositoryApplicationService;
 
-    private readonly bool _updateRepositoriesOnStateMismatch;
-
     public ECRRepositoryService(
         ILogger<ECRRepositoryService> logger,
         IECRRepositoryRepository ecrRepositoryRepository,
@@ -20,8 +18,6 @@ public class ECRRepositoryService : IECRRepositoryService
         _logger = logger;
         _ecrRepositoryRepository = ecrRepositoryRepository;
         _awsEcrRepositoryApplicationService = awsEcrRepositoryApplicationService;
-        _updateRepositoriesOnStateMismatch =
-            Environment.GetEnvironmentVariable("UPDATE_REPOSITORIES_ON_STATE_MISMATCH") == "true";
     }
 
     public Task<IEnumerable<ECRRepository>> GetAllECRRepositories()
@@ -52,7 +48,7 @@ public class ECRRepositoryService : IECRRepositoryService
         }
     }
 
-    public async Task SynchronizeAwsECRAndDatabase()
+    public async Task SynchronizeAwsECRAndDatabase(bool performUpdateOnMismatch)
     {
         var awsRepositoriesSet = new HashSet<string>(await _awsEcrRepositoryApplicationService.GetECRRepositories());
 
@@ -87,7 +83,7 @@ public class ECRRepositoryService : IECRRepositoryService
                 }
             });
 
-        if (!_updateRepositoriesOnStateMismatch)
+        if (!performUpdateOnMismatch)
         {
             if (repositoriesNotInAws.Count > 0 || repositoriesNotInDb.Count > 0)
             {

--- a/src/SelfService/Domain/Services/IAuthorizationService.cs
+++ b/src/SelfService/Domain/Services/IAuthorizationService.cs
@@ -24,4 +24,5 @@ public interface IAuthorizationService
     Task<bool> CanViewAllApplications(UserId userId, CapabilityId capabilityId);
     Task<bool> CanDeleteCapability(UserId userId, CapabilityId capabilityId);
     bool CanViewDeletedCapabilities(PortalUser portalUser);
+    bool CanSynchronizeAwsECRAndDatabaseECR(PortalUser portalUser);
 }

--- a/src/SelfService/Domain/Services/IECRRepositoryService.cs
+++ b/src/SelfService/Domain/Services/IECRRepositoryService.cs
@@ -6,5 +6,5 @@ public interface IECRRepositoryService
 {
     Task<IEnumerable<ECRRepository>> GetAllECRRepositories();
     Task<ECRRepository> AddRepository(string name, string description, string repositoryName, UserId userId);
-    Task SynchronizeAwsECRAndDatabase();
+    Task SynchronizeAwsECRAndDatabase(bool performUpdateOnMismatch = false);
 }

--- a/src/SelfService/Infrastructure/Api/CustomObjectResults.cs
+++ b/src/SelfService/Infrastructure/Api/CustomObjectResults.cs
@@ -6,6 +6,9 @@ public static class CustomObjectResults
 {
     [NonAction]
     public static InternalServerErrorResult InternalServerError(object error) => new(error);
+
+    [NonAction]
+    public static MethodNotAllowedErrorResult MethodNotAllowedError(object error) => new(error);
 }
 
 public class InternalServerErrorResult : ObjectResult
@@ -13,6 +16,17 @@ public class InternalServerErrorResult : ObjectResult
     private const int DefaultStatusCode = StatusCodes.Status500InternalServerError;
 
     public InternalServerErrorResult(object error)
+        : base(error)
+    {
+        StatusCode = DefaultStatusCode;
+    }
+}
+
+public class MethodNotAllowedErrorResult : ObjectResult
+{
+    private const int DefaultStatusCode = StatusCodes.Status405MethodNotAllowed;
+
+    public MethodNotAllowedErrorResult(object error)
         : base(error)
     {
         StatusCode = DefaultStatusCode;

--- a/src/SelfService/Infrastructure/BackgroundJobs/ECRRepositorySynchronizer.cs
+++ b/src/SelfService/Infrastructure/BackgroundJobs/ECRRepositorySynchronizer.cs
@@ -1,0 +1,48 @@
+using SelfService.Domain.Services;
+
+namespace SelfService.Infrastructure.BackgroundJobs;
+
+public class ECRRepositorySynchronizer : BackgroundService
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly ILogger<ECRRepositorySynchronizer> _logger;
+    private readonly bool _updateRepositoriesOnStateMismatch;
+
+    public ECRRepositorySynchronizer(IServiceProvider serviceProvider, ILogger<ECRRepositorySynchronizer> logger)
+    {
+        _serviceProvider = serviceProvider;
+        _logger = logger;
+
+        _updateRepositoriesOnStateMismatch =
+            Environment.GetEnvironmentVariable("UPDATE_REPOSITORIES_ON_STATE_MISMATCH") == "true";
+    }
+
+    protected override Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        return Task.Run(
+            async () =>
+            {
+                while (!stoppingToken.IsCancellationRequested)
+                {
+                    await DoWork(stoppingToken);
+                    await Task.Delay(TimeSpan.FromHours(24), stoppingToken);
+                }
+            },
+            stoppingToken
+        );
+    }
+
+    private async Task DoWork(CancellationToken cancellationToken)
+    {
+        using var scope = _serviceProvider.CreateScope();
+
+        using var _ = _logger.BeginScope(
+            "{BackgroundJob} {CorrelationId}",
+            nameof(ECRRepositorySynchronizer),
+            Guid.NewGuid()
+        );
+        var ecrRepositoryService = scope.ServiceProvider.GetRequiredService<IECRRepositoryService>();
+
+        await ecrRepositoryService.SynchronizeAwsECRAndDatabase(_updateRepositoriesOnStateMismatch);
+    }
+}

--- a/src/SelfService/Infrastructure/BackgroundJobs/ECRRepositorySynchronizer.cs
+++ b/src/SelfService/Infrastructure/BackgroundJobs/ECRRepositorySynchronizer.cs
@@ -43,6 +43,13 @@ public class ECRRepositorySynchronizer : BackgroundService
         );
         var ecrRepositoryService = scope.ServiceProvider.GetRequiredService<IECRRepositoryService>();
 
-        await ecrRepositoryService.SynchronizeAwsECRAndDatabase(_updateRepositoriesOnStateMismatch);
+        try
+        {
+            await ecrRepositoryService.SynchronizeAwsECRAndDatabase(_updateRepositoriesOnStateMismatch);
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, "Error synchronizing ECR repositories");
+        }
     }
 }

--- a/src/SelfService/Infrastructure/Persistence/ECRRepositoryRepository.cs
+++ b/src/SelfService/Infrastructure/Persistence/ECRRepositoryRepository.cs
@@ -17,9 +17,16 @@ public class ECRRepositoryRepository : IECRRepositoryRepository
         return await _dbContext.ECRRepositories.ToListAsync();
     }
 
-    public void Add(ECRRepository ecr)
+    public async Task Add(ECRRepository ecrRepository)
     {
-        _dbContext.ECRRepositories.Add(ecr);
+        await _dbContext.ECRRepositories.AddAsync(ecrRepository);
+        await _dbContext.SaveChangesAsync();
+    }
+
+    public async Task AddRange(List<ECRRepository> ecrRepositories)
+    {
+        await _dbContext.AddRangeAsync(ecrRepositories);
+        await _dbContext.SaveChangesAsync();
     }
 
     public Task RemoveWithRepositoryName(string repositoryName)

--- a/src/SelfService/Infrastructure/Persistence/ECRRepositoryRepository.cs
+++ b/src/SelfService/Infrastructure/Persistence/ECRRepositoryRepository.cs
@@ -1,4 +1,5 @@
 using Microsoft.EntityFrameworkCore;
+using SelfService.Domain;
 using SelfService.Domain.Models;
 
 namespace SelfService.Infrastructure.Persistence;
@@ -17,22 +18,22 @@ public class ECRRepositoryRepository : IECRRepositoryRepository
         return await _dbContext.ECRRepositories.ToListAsync();
     }
 
+    [TransactionalBoundary]
     public async Task Add(ECRRepository ecrRepository)
     {
         await _dbContext.ECRRepositories.AddAsync(ecrRepository);
-        await _dbContext.SaveChangesAsync();
     }
 
+    [TransactionalBoundary]
     public async Task AddRange(List<ECRRepository> ecrRepositories)
     {
         await _dbContext.AddRangeAsync(ecrRepositories);
-        await _dbContext.SaveChangesAsync();
     }
 
-    public Task RemoveWithRepositoryName(string repositoryName)
+    [TransactionalBoundary]
+    public void RemoveRangeWithRepositoryName(List<string> repositoryNames)
     {
-        var repo = _dbContext.ECRRepositories.Single(x => x.RepositoryName == repositoryName);
-        _dbContext.ECRRepositories.Remove(repo);
-        return _dbContext.SaveChangesAsync();
+        var repositories = _dbContext.ECRRepositories.Where(x => repositoryNames.Contains(x.RepositoryName));
+        _dbContext.ECRRepositories.RemoveRange(repositories);
     }
 }

--- a/src/SelfService/Infrastructure/Persistence/ECRRepositoryRepository.cs
+++ b/src/SelfService/Infrastructure/Persistence/ECRRepositoryRepository.cs
@@ -27,7 +27,7 @@ public class ECRRepositoryRepository : IECRRepositoryRepository
     [TransactionalBoundary]
     public async Task AddRange(List<ECRRepository> ecrRepositories)
     {
-        await _dbContext.AddRangeAsync(ecrRepositories);
+        await _dbContext.ECRRepositories.AddRangeAsync(ecrRepositories);
     }
 
     [TransactionalBoundary]

--- a/src/SelfService/Infrastructure/Persistence/ECRRepositoryRepository.cs
+++ b/src/SelfService/Infrastructure/Persistence/ECRRepositoryRepository.cs
@@ -33,6 +33,6 @@ public class ECRRepositoryRepository : IECRRepositoryRepository
     {
         var repo = _dbContext.ECRRepositories.Single(x => x.RepositoryName == repositoryName);
         _dbContext.ECRRepositories.Remove(repo);
-        return Task.CompletedTask;
+        return _dbContext.SaveChangesAsync();
     }
 }


### PR DESCRIPTION
closes dfds/cloudplatform/issues/2028

## Additional Review Notes
Contains fix that makes it possible to add/remove ecr into/from database. Was previously broken because of missing db commit.

Also includes an endpoint for triggering it manually. Currently only cloud engineers can make it actually update the database.

### Examples

**When simply checking:**
<img width="1423" alt="image" src="https://github.com/dfds/selfservice-api/assets/5738476/68ada0de-94ed-424a-9878-435f7d053a49">

**When altering:**
<img width="1418" alt="image" src="https://github.com/dfds/selfservice-api/assets/5738476/7fefd0e6-f3fd-4c74-a003-9489886f48fc">