### PR TITLE
made it so that we can await SetToken

### DIFF
--- a/src/SelfService.Tests/TestDoubles/StubUserStatusChecker.cs
+++ b/src/SelfService.Tests/TestDoubles/StubUserStatusChecker.cs
@@ -14,7 +14,7 @@ public class StubUserStatusChecker : IUserStatusChecker
         SetAuthToken();
     }
 
-    public bool TrySetAuthToken()
+    public Task<bool> TrySetAuthToken()
     {
         return false;
     }

--- a/src/SelfService.Tests/TestDoubles/StubUserStatusChecker.cs
+++ b/src/SelfService.Tests/TestDoubles/StubUserStatusChecker.cs
@@ -6,23 +6,11 @@ namespace SelfService.Tests.TestDoubles;
 
 public class StubUserStatusChecker : IUserStatusChecker
 {
-    private readonly ILogger<RemoveDeactivatedMemberships> _logger; //depends on that background job
-
-    public StubUserStatusChecker(ILogger<RemoveDeactivatedMemberships> logger)
-    {
-        _logger = logger;
-        SetAuthToken();
-    }
-
     public Task<bool> TrySetAuthToken()
     {
-        return false;
+        return Task.FromResult(false);
     }
-
-    private void SetAuthToken()
-    {
-        return; //so we can await it
-    }
+    
 
     private Task<bool> BusyWait()
     {

--- a/src/SelfService/Application/DeactivatedMemberCleanerApplicationService.cs
+++ b/src/SelfService/Application/DeactivatedMemberCleanerApplicationService.cs
@@ -42,7 +42,7 @@ public class DeactivatedMemberCleanerApplicationService
     public async Task RemoveDeactivatedMemberships(IUserStatusChecker userStatusChecker)
     {
         _logger.LogDebug("Started looking for deactivated users");
-        if (!userStatusChecker.TrySetAuthToken())
+        if (!(await userStatusChecker.TrySetAuthToken()))
         {
             _logger.LogError("Unable to Remove Deactivated Memberships, no valid auth token found");
             return;

--- a/src/SelfService/Infrastructure/BackgroundJobs/IUserStatusChecker.cs
+++ b/src/SelfService/Infrastructure/BackgroundJobs/IUserStatusChecker.cs
@@ -6,5 +6,5 @@ namespace SelfService.Infrastructure.BackgroundJobs;
 public interface IUserStatusChecker
 {
     Task<UserStatusCheckerStatus> CheckUserStatus(string userId);
-    bool TrySetAuthToken();
+    Task<bool> TrySetAuthToken();
 }

--- a/src/SelfService/Infrastructure/BackgroundJobs/UserStatusChecker.cs
+++ b/src/SelfService/Infrastructure/BackgroundJobs/UserStatusChecker.cs
@@ -15,10 +15,9 @@ public class UserStatusChecker : IUserStatusChecker
     public UserStatusChecker(ILogger<RemoveDeactivatedMemberships> logger)
     {
         _logger = logger;
-        SetAuthToken();
     }
 
-    private async void SetAuthToken()
+    private async Task SetAuthToken()
     {
         /*
             makes an MS-Graph request to get the temporary creds
@@ -94,11 +93,11 @@ public class UserStatusChecker : IUserStatusChecker
     }
 
     /// <returns> true if AuthToken is set or was set sucessfully</returns>
-    public bool TrySetAuthToken()
+    public async Task<bool> TrySetAuthToken()
     {
         if (_authToken == null)
         {
-            SetAuthToken();
+            await SetAuthToken();
         }
         return _authToken != null;
     }
@@ -113,7 +112,7 @@ public class UserStatusChecker : IUserStatusChecker
             _logger.LogError(
                 "[UserStatusChecker] cannot make user request, `authToken` is not set, attempting to set `authToken`"
             );
-            if (!TrySetAuthToken())
+            if (!(await TrySetAuthToken()))
             {
                 _logger.LogError("[UserStatusChecker] Failed setting authToken: cancelling CheckUserStatus");
                 return UserStatusCheckerStatus.NoAuthToken;


### PR DESCRIPTION
closes dfds/cloudplatform/issues/2097

# Additional Review Notes
problem was discovered when inspecting production logs:
SetToken was successfully setting the token, but the methods which used the token in the outer scope were behaving as if it wasn't properly set.

Problem was that SetToken was being called synchronously in an async context, which meant the TrySetToken would return without waiting on it, and the UserStatusChecker would thus fail.
