### PR TITLE
2173 let cloud engineers able to join any capability without approval

### DIFF
--- a/src/SelfService.Tests/Application/TestMembershipApplicationService.cs
+++ b/src/SelfService.Tests/Application/TestMembershipApplicationService.cs
@@ -1,0 +1,27 @@
+using Microsoft.EntityFrameworkCore;
+using SelfService.Application;
+using SelfService.Domain.Models;
+
+namespace SelfService.Tests.Application;
+
+public class TestMembershipApplicationService
+{
+    [Fact]
+    [Trait("Category", "InMemoryDatabase")]
+    public async Task addandcreatemembership_cant_create_duplicate_membership()
+    {
+        //create dbContext which also is provides stub argument for MembershipRepository
+        await using var databaseFactory = new InMemoryDatabaseFactory();
+        var dbContext = await databaseFactory.CreateDbContext();
+        UserId userId = "chungus@dfds.com";
+        CapabilityId capabilityId= "reflect2improve-GPU-cluster-mgmt-qxyz";
+        var membershipRepo = A.MembershipRepository.WithDbContext(dbContext).Build();
+        MembershipApplicationService membershipApplicationService = A.MembershipApplicationService.WithMembershipRepository(membershipRepo).Build();
+        await membershipApplicationService.CreateAndAddMembership(capabilityId, userId);
+        await membershipApplicationService.CreateAndAddMembership(capabilityId, userId);
+        var memberships = await dbContext.Memberships.ToListAsync();
+        //Assert.Equal(1, memberships.Count); <- throws a C# error, leaving this here because I want to learn the reason why
+        Assert.Single(memberships);
+    }
+
+}

--- a/src/SelfService.Tests/Builders/A.cs
+++ b/src/SelfService.Tests/Builders/A.cs
@@ -7,7 +7,6 @@ namespace SelfService.Tests.Builders;
 public static class A
 {
     public static UserId UserId => UserId.Parse("foo");
-
     public static CapabilityBuilder Capability => new();
     public static MembershipBuilder Membership => new();
     public static MemberBuilder Member => new();
@@ -29,4 +28,5 @@ public static class A
 
     public static ECRRepositoryBuilder ECRRepository => new();
     public static ECRRepositoryRepositoryBuilder ECRRepositoryRepository => new();
+    public static MembershipApplicationServiceBuilder MembershipApplicationService => new();
 }

--- a/src/SelfService.Tests/Builders/MembershipApplicationServiceBuilder.cs
+++ b/src/SelfService.Tests/Builders/MembershipApplicationServiceBuilder.cs
@@ -1,0 +1,50 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using SelfService.Application;
+using SelfService.Domain;
+using SelfService.Domain.Models;
+using SelfService.Domain.Queries;
+using SelfService.Domain.Services;
+using SelfService.Tests.TestDoubles;
+
+namespace SelfService.Tests.Builders;
+
+public class MembershipApplicationServiceBuilder
+{
+    private IMembershipRepository _membershipRepository;
+    /*
+    //uncomment if other functionality needs to be tested
+    private ICapabilityRepository _capabilityRepository;
+    private readonly IMembershipApplicationRepository _membershipApplicationRepository;
+    private IAuthorizationService _authorizationService;
+    private IMembershipQuery _membershipQuery;
+    private MembershipApplicationDomainService _membershipApplicationDomainService;
+    */
+
+    public MembershipApplicationServiceBuilder(){
+        _membershipRepository = Dummy.Of<IMembershipRepository>();
+    }
+
+    public MembershipApplicationServiceBuilder WithMembershipRepository(IMembershipRepository membershipRepository)
+    {
+        _membershipRepository = membershipRepository;
+        return this;
+    }
+
+    public MembershipApplicationService Build()
+    {
+        return new MembershipApplicationService(
+            logger: NullLogger<MembershipApplicationService>.Instance,
+            capabilityRepository: Mock.Of<ICapabilityRepository>(),
+            membershipRepository: _membershipRepository,
+            membershipApplicationRepository:Mock.Of<IMembershipApplicationRepository>(),
+            authorizationService:Mock.Of<IAuthorizationService>(),
+            systemTime: SystemTime.Default,
+            membershipQuery:Mock.Of<IMembershipQuery>(),
+            membershipApplicationDomainService:Mock.Of<IMembershipApplicationDomainService>()
+        );
+    }
+    
+    public static implicit operator MembershipApplicationService(MembershipApplicationServiceBuilder builder) =>
+        builder.Build();
+}

--- a/src/SelfService.Tests/Builders/MembershipApplicationServiceBuilder.cs
+++ b/src/SelfService.Tests/Builders/MembershipApplicationServiceBuilder.cs
@@ -12,6 +12,7 @@ namespace SelfService.Tests.Builders;
 public class MembershipApplicationServiceBuilder
 {
     private IMembershipRepository _membershipRepository;
+
     /*
     //uncomment if other functionality needs to be tested
     private ICapabilityRepository _capabilityRepository;
@@ -21,7 +22,8 @@ public class MembershipApplicationServiceBuilder
     private MembershipApplicationDomainService _membershipApplicationDomainService;
     */
 
-    public MembershipApplicationServiceBuilder(){
+    public MembershipApplicationServiceBuilder()
+    {
         _membershipRepository = Dummy.Of<IMembershipRepository>();
     }
 
@@ -37,14 +39,14 @@ public class MembershipApplicationServiceBuilder
             logger: NullLogger<MembershipApplicationService>.Instance,
             capabilityRepository: Mock.Of<ICapabilityRepository>(),
             membershipRepository: _membershipRepository,
-            membershipApplicationRepository:Mock.Of<IMembershipApplicationRepository>(),
-            authorizationService:Mock.Of<IAuthorizationService>(),
+            membershipApplicationRepository: Mock.Of<IMembershipApplicationRepository>(),
+            authorizationService: Mock.Of<IAuthorizationService>(),
             systemTime: SystemTime.Default,
-            membershipQuery:Mock.Of<IMembershipQuery>(),
-            membershipApplicationDomainService:Mock.Of<IMembershipApplicationDomainService>()
+            membershipQuery: Mock.Of<IMembershipQuery>(),
+            membershipApplicationDomainService: Mock.Of<IMembershipApplicationDomainService>()
         );
     }
-    
+
     public static implicit operator MembershipApplicationService(MembershipApplicationServiceBuilder builder) =>
         builder.Build();
 }

--- a/src/SelfService/Application/IMembershipApplicationService.cs
+++ b/src/SelfService/Application/IMembershipApplicationService.cs
@@ -12,4 +12,5 @@ public interface IMembershipApplicationService
     Task AddCreatorAsInitialMember(CapabilityId capabilityId, UserId creatorId);
     Task RemoveMembershipApplication(MembershipApplicationId applicationId);
     Task LeaveCapability(CapabilityId capabilityId, UserId userId);
+    Task AddUserToCapability(CapabilityId capabilityId, UserId userId);
 }

--- a/src/SelfService/Application/MembershipApplicationService.cs
+++ b/src/SelfService/Application/MembershipApplicationService.cs
@@ -15,7 +15,7 @@ public class MembershipApplicationService : IMembershipApplicationService
     private readonly IAuthorizationService _authorizationService;
     private readonly SystemTime _systemTime;
     private readonly IMembershipQuery _membershipQuery;
-    private readonly MembershipApplicationDomainService _membershipApplicationDomainService;
+    private readonly IMembershipApplicationDomainService _membershipApplicationDomainService;
 
     public MembershipApplicationService(
         ILogger<MembershipApplicationService> logger,
@@ -25,7 +25,7 @@ public class MembershipApplicationService : IMembershipApplicationService
         IAuthorizationService authorizationService,
         SystemTime systemTime,
         IMembershipQuery membershipQuery,
-        MembershipApplicationDomainService membershipApplicationDomainService
+        IMembershipApplicationDomainService membershipApplicationDomainService
     )
     {
         _logger = logger;
@@ -38,7 +38,7 @@ public class MembershipApplicationService : IMembershipApplicationService
         _membershipApplicationDomainService = membershipApplicationDomainService;
     }
 
-    private async Task CreateAndAddMembership(CapabilityId capabilityId, UserId userId){
+    public async Task CreateAndAddMembership(CapabilityId capabilityId, UserId userId){
         var newMembership = Membership.CreateFor(
             capabilityId: capabilityId,
             userId: userId,

--- a/src/SelfService/Configuration/Domain.cs
+++ b/src/SelfService/Configuration/Domain.cs
@@ -29,7 +29,7 @@ public static class Domain
         builder.Services.AddTransient<IAwsECRRepositoryApplicationService, AwsEcrRepositoryApplicationService>();
 
         // domain services
-        builder.Services.AddTransient<MembershipApplicationDomainService>();
+        builder.Services.AddTransient<IMembershipApplicationDomainService, MembershipApplicationDomainService>();
         builder.Services.AddTransient<IAuthorizationService, AuthorizationService>();
         builder.Services.AddTransient<IECRRepositoryService, ECRRepositoryService>();
         builder.Services.AddTransient<ISelfServiceJsonSchemaService, SelfServiceJsonSchemaService>();

--- a/src/SelfService/Domain/Models/IMembershipRepository.cs
+++ b/src/SelfService/Domain/Models/IMembershipRepository.cs
@@ -4,6 +4,7 @@ public interface IMembershipRepository
 {
     Task Add(Membership membership);
     Task<IEnumerable<Membership>> FindBy(CapabilityId capabilityId);
+    Task<bool> IsAlreadyMember(CapabilityId capabilityId, UserId userId);
     Task<Membership?> CancelWithCapabilityId(CapabilityId capabilityId, UserId userId);
     Task<List<Membership>> CancelAllMembershipsWithUserId(UserId userId);
 }

--- a/src/SelfService/Domain/Services/AuthorizationService.cs
+++ b/src/SelfService/Domain/Services/AuthorizationService.cs
@@ -191,4 +191,9 @@ public class AuthorizationService : IAuthorizationService
     {
         return portalUser.Roles.Any(role => role == UserRole.CloudEngineer);
     }
+
+    public bool CanBypassMembershipApprovals(PortalUser portalUser)
+    {
+        return portalUser.Roles.Any(role => role == UserRole.CloudEngineer);
+    }
 }

--- a/src/SelfService/Domain/Services/IAuthorizationService.cs
+++ b/src/SelfService/Domain/Services/IAuthorizationService.cs
@@ -26,4 +26,5 @@ public interface IAuthorizationService
     bool CanViewDeletedCapabilities(PortalUser portalUser);
     bool CanSynchronizeAwsECRAndDatabaseECR(PortalUser portalUser);
     bool CanSetCapabilityJsonMetadata(PortalUser portalUser);
+    bool CanBypassMembershipApprovals(PortalUser portalUser);
 }

--- a/src/SelfService/Domain/Services/IMembershipApplicationDomainService.cs
+++ b/src/SelfService/Domain/Services/IMembershipApplicationDomainService.cs
@@ -2,6 +2,7 @@ using SelfService.Domain.Models;
 using SelfService.Domain.Queries;
 
 namespace SelfService.Domain.Services;
+
 public interface IMembershipApplicationDomainService
 {
     bool CanBeFinalized(MembershipApplication application);

--- a/src/SelfService/Domain/Services/IMembershipApplicationDomainService.cs
+++ b/src/SelfService/Domain/Services/IMembershipApplicationDomainService.cs
@@ -1,0 +1,9 @@
+using SelfService.Domain.Models;
+using SelfService.Domain.Queries;
+
+namespace SelfService.Domain.Services;
+public interface IMembershipApplicationDomainService
+{
+    bool CanBeFinalized(MembershipApplication application);
+    public Task<bool> CanApprove(UserId userId, MembershipApplication application);
+}

--- a/src/SelfService/Domain/Services/MembershipApplicationDomainService.cs
+++ b/src/SelfService/Domain/Services/MembershipApplicationDomainService.cs
@@ -3,7 +3,7 @@ using SelfService.Domain.Queries;
 
 namespace SelfService.Domain.Services;
 
-public class MembershipApplicationDomainService
+public class MembershipApplicationDomainService : IMembershipApplicationDomainService
 {
     private readonly IMembershipRepository _membershipRepository;
     private readonly IMembershipQuery _membershipQuery;

--- a/src/SelfService/Infrastructure/Api/Capabilities/CapabilityController.cs
+++ b/src/SelfService/Infrastructure/Api/Capabilities/CapabilityController.cs
@@ -13,19 +13,19 @@ namespace SelfService.Infrastructure.Api.Capabilities;
 [ApiController]
 public class CapabilityController : ControllerBase
 {
-    private readonly ICapabilityMembersQuery _membersQuery;
-    private readonly ICapabilityRepository _capabilityRepository;
-    private readonly IKafkaTopicRepository _kafkaTopicRepository;
     private readonly ApiResourceFactory _apiResourceFactory;
     private readonly IAuthorizationService _authorizationService;
-    private readonly IKafkaClusterRepository _kafkaClusterRepository;
-    private readonly ICapabilityApplicationService _capabilityApplicationService;
-    private readonly IAwsAccountRepository _awsAccountRepository;
     private readonly IAwsAccountApplicationService _awsAccountApplicationService;
-    private readonly IMembershipApplicationService _membershipApplicationService;
+    private readonly IAwsAccountRepository _awsAccountRepository;
+    private readonly ICapabilityApplicationService _capabilityApplicationService;
+    private readonly ICapabilityRepository _capabilityRepository;
     private readonly IKafkaClusterAccessRepository _kafkaClusterAccessRepository;
-    private readonly ISelfServiceJsonSchemaService _selfServiceJsonSchemaService;
+    private readonly IKafkaClusterRepository _kafkaClusterRepository;
+    private readonly IKafkaTopicRepository _kafkaTopicRepository;
     private readonly ILogger<CapabilityController> _logger;
+    private readonly IMembershipApplicationService _membershipApplicationService;
+    private readonly ICapabilityMembersQuery _membersQuery;
+    private readonly ISelfServiceJsonSchemaService _selfServiceJsonSchemaService;
 
     public CapabilityController(
         ICapabilityMembersQuery membersQuery,
@@ -74,23 +74,15 @@ public class CapabilityController : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict, "application/problem+json")]
     public async Task<IActionResult> CreateNewCapability([FromBody] NewCapabilityRequest request)
     {
-        if (!User.TryGetUserId(out var userId))
-        {
-            return Unauthorized();
-        }
+        if (!User.TryGetUserId(out var userId)) return Unauthorized();
 
         if (!CapabilityId.TryCreateFrom(request.Name, out var capabilityId))
-        {
             ModelState.AddModelError(
                 nameof(request.Name),
                 $"unable to create capability ID from name \"{request.Name}\""
             );
-        }
 
-        if (!ModelState.IsValid)
-        {
-            return ValidationProblem();
-        }
+        if (!ModelState.IsValid) return ValidationProblem();
 
         // See if request has valid json metadata
         var jsonMetadataResult = await _selfServiceJsonSchemaService.ValidateJsonMetadata(
@@ -99,7 +91,6 @@ public class CapabilityController : ControllerBase
         );
 
         if (!jsonMetadataResult.IsValid())
-        {
             return BadRequest(
                 new ProblemDetails
                 {
@@ -108,7 +99,6 @@ public class CapabilityController : ControllerBase
                     Status = StatusCodes.Status400BadRequest
                 }
             );
-        }
 
         _logger.LogInformation(
             "Successfully parsed json meta data: {ParseResultCode}",
@@ -117,11 +107,9 @@ public class CapabilityController : ControllerBase
 
         // Sanity check: should not be possible if result is valid
         if (jsonMetadataResult.JsonMetadata == null)
-        {
             return CustomObjectResult.InternalServerError(
-                new ProblemDetails() { Title = "Internal server error", Detail = "JsonMetadataResult is null", }
+                new ProblemDetails { Title = "Internal server error", Detail = "JsonMetadataResult is null" }
             );
-        }
 
         try
         {
@@ -145,10 +133,10 @@ public class CapabilityController : ControllerBase
 
         var capability = await _capabilityRepository.Get(capabilityId);
         return CreatedAtAction(
-            actionName: nameof(GetCapabilityById),
-            controllerName: "Capability",
-            routeValues: new { id = capability.Id },
-            value: await _apiResourceFactory.Convert(capability)
+            nameof(GetCapabilityById),
+            "Capability",
+            new { id = capability.Id },
+            await _apiResourceFactory.Convert(capability)
         );
     }
 
@@ -159,19 +147,16 @@ public class CapabilityController : ControllerBase
     public async Task<IActionResult> GetCapabilityById(string id)
     {
         if (!User.TryGetUserId(out _))
-        {
             return Unauthorized(
                 new ProblemDetails
                 {
                     Title = "Access denied!",
-                    Detail = $"The user id is not valid and access to the resource cannot be granted.",
+                    Detail = "The user id is not valid and access to the resource cannot be granted.",
                     Status = StatusCodes.Status401Unauthorized
                 }
             );
-        }
 
         if (!CapabilityId.TryParse(id, out var capabilityId))
-        {
             return NotFound(
                 new ProblemDetails
                 {
@@ -180,11 +165,9 @@ public class CapabilityController : ControllerBase
                     Status = StatusCodes.Status404NotFound
                 }
             );
-        }
 
         var capability = await _capabilityRepository.FindBy(capabilityId);
         if (capability is null)
-        {
             return NotFound(
                 new ProblemDetails
                 {
@@ -193,7 +176,6 @@ public class CapabilityController : ControllerBase
                     Status = StatusCodes.Status404NotFound
                 }
             );
-        }
 
         return Ok(await _apiResourceFactory.Convert(capability));
     }
@@ -204,14 +186,9 @@ public class CapabilityController : ControllerBase
     public async Task<IActionResult> GetCapabilityMembers(string id)
     {
         if (!CapabilityId.TryParse(id, out var capabilityId))
-        {
             ModelState.AddModelError(nameof(id), $"Value \"{id}\" is not a valid capability id.");
-        }
 
-        if (!ModelState.IsValid)
-        {
-            return ValidationProblem();
-        }
+        if (!ModelState.IsValid) return ValidationProblem();
 
         var members = await _membersQuery.FindBy(capabilityId);
 
@@ -224,31 +201,16 @@ public class CapabilityController : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound, "application/problem+json")]
     public async Task<IActionResult> GetCapabilityAwsAccount(string id)
     {
-        if (!User.TryGetUserId(out var userId))
-        {
-            return Unauthorized();
-        }
+        if (!User.TryGetUserId(out var userId)) return Unauthorized();
 
-        if (!CapabilityId.TryParse(id, out var capabilityId))
-        {
-            return NotFound();
-        }
+        if (!CapabilityId.TryParse(id, out var capabilityId)) return NotFound();
 
-        if (!await _capabilityRepository.Exists(capabilityId))
-        {
-            return NotFound();
-        }
+        if (!await _capabilityRepository.Exists(capabilityId)) return NotFound();
 
-        if (!await _authorizationService.CanViewAwsAccount(userId, capabilityId))
-        {
-            return Unauthorized();
-        }
+        if (!await _authorizationService.CanViewAwsAccount(userId, capabilityId)) return Unauthorized();
 
         var account = await _awsAccountRepository.FindBy(capabilityId);
-        if (account is null)
-        {
-            return NotFound();
-        }
+        if (account is null) return NotFound();
 
         return Ok(await _apiResourceFactory.Convert(account));
     }
@@ -260,25 +222,13 @@ public class CapabilityController : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict, "application/problem+json")]
     public async Task<IActionResult> RequestAwsAccount(string id, [FromServices] SelfServiceDbContext dbContext)
     {
-        if (!User.TryGetUserId(out var userId))
-        {
-            return Unauthorized();
-        }
+        if (!User.TryGetUserId(out var userId)) return Unauthorized();
 
-        if (!CapabilityId.TryParse(id, out var capabilityId))
-        {
-            return NotFound();
-        }
+        if (!CapabilityId.TryParse(id, out var capabilityId)) return NotFound();
 
-        if (!await _capabilityRepository.Exists(capabilityId))
-        {
-            return NotFound();
-        }
+        if (!await _capabilityRepository.Exists(capabilityId)) return NotFound();
 
-        if (!await _authorizationService.CanRequestAwsAccount(userId, capabilityId))
-        {
-            return Unauthorized();
-        }
+        if (!await _authorizationService.CanRequestAwsAccount(userId, capabilityId)) return Unauthorized();
 
         try
         {
@@ -303,28 +253,17 @@ public class CapabilityController : ControllerBase
         [FromServices] ICapabilityMembershipApplicationQuery query
     )
     {
-        if (!User.TryGetUserId(out var userId))
-        {
-            return Unauthorized();
-        }
+        if (!User.TryGetUserId(out var userId)) return Unauthorized();
 
-        if (!CapabilityId.TryParse(id, out var capabilityId))
-        {
-            return NotFound();
-        }
+        if (!CapabilityId.TryParse(id, out var capabilityId)) return NotFound();
 
-        if (!await _capabilityRepository.Exists(capabilityId))
-        {
-            return NotFound();
-        }
+        if (!await _capabilityRepository.Exists(capabilityId)) return NotFound();
 
         var applications = await query.FindPendingBy(capabilityId);
 
         if (!await _authorizationService.CanViewAllApplications(userId, capabilityId))
-        {
             // only allow the current users own application(s)
             applications = applications.Where(x => x.Applicant == userId).ToList();
-        }
 
         var resource = await _apiResourceFactory.Convert(capabilityId, applications, userId);
 
@@ -343,20 +282,11 @@ public class CapabilityController : ControllerBase
         [FromServices] IMembershipApplicationRepository membershipApplicationRepository
     )
     {
-        if (!User.TryGetUserId(out var userId))
-        {
-            return Unauthorized();
-        }
+        if (!User.TryGetUserId(out var userId)) return Unauthorized();
 
-        if (!CapabilityId.TryParse(id, out var capabilityId))
-        {
-            return NotFound();
-        }
+        if (!CapabilityId.TryParse(id, out var capabilityId)) return NotFound();
 
-        if (!await _capabilityRepository.Exists(capabilityId))
-        {
-            return NotFound();
-        }
+        if (!await _capabilityRepository.Exists(capabilityId)) return NotFound();
 
         try
         {
@@ -365,10 +295,10 @@ public class CapabilityController : ControllerBase
 
             // TODO [jandr@2023-04-12]: refactor this! this is intimate knowledge of another controller
             return CreatedAtAction(
-                actionName: "GetById",
-                controllerName: "MembershipApplication",
-                routeValues: new { id = applicationId.ToString() },
-                value: _apiResourceFactory.Convert(membershipApplication, userId)
+                "GetById",
+                "MembershipApplication",
+                new { id = applicationId.ToString() },
+                _apiResourceFactory.Convert(membershipApplication, userId)
             );
         }
         catch (EntityNotFoundException<Capability>)
@@ -412,95 +342,70 @@ public class CapabilityController : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict, "application/problem+json")]
     public async Task<IActionResult> AddCapabilityTopic(string id, [FromBody] NewKafkaTopicRequest topicRequest)
     {
-        if (!User.TryGetUserId(out var userId))
-        {
-            return Unauthorized();
-        }
+        if (!User.TryGetUserId(out var userId)) return Unauthorized();
 
-        if (!CapabilityId.TryParse(id, out var capabilityId))
-        {
-            return NotFound();
-        }
+        if (!CapabilityId.TryParse(id, out var capabilityId)) return NotFound();
 
-        if (!await _capabilityRepository.Exists(capabilityId))
-        {
-            return NotFound();
-        }
+        if (!await _capabilityRepository.Exists(capabilityId)) return NotFound();
 
         if (!KafkaClusterId.TryParse(topicRequest.KafkaClusterId, out var kafkaClusterId))
-        {
             ModelState.AddModelError(
                 nameof(topicRequest.KafkaClusterId),
                 $"Value \"{topicRequest.KafkaClusterId}\" is not a valid kafka cluster id."
             );
-        }
 
         if (!KafkaTopicName.TryParse(topicRequest.Name, out var kafkaTopicName))
-        {
             ModelState.AddModelError(
                 nameof(topicRequest.Name),
                 $"Value \"{topicRequest.Name}\" is not a valid kafka topic name."
             );
-        }
 
         if (!KafkaTopicPartitions.TryCreate(topicRequest.Partitions ?? 0, out var topicPartitions))
-        {
             ModelState.AddModelError(
                 nameof(topicRequest.Partitions),
                 $"Value \"{topicRequest.Partitions}\" is invalid for kafka topic partitions."
             );
-        }
 
         if (!KafkaTopicRetention.TryParse(topicRequest.Retention, out var topicRetention))
-        {
             ModelState.AddModelError(
                 nameof(topicRequest.Retention),
                 $"Value \"{topicRequest.Retention}\" is invalid for kafka topic retention."
             );
-        }
 
         if (!await _kafkaClusterRepository.Exists(kafkaClusterId))
-        {
             ModelState.AddModelError(
                 nameof(topicRequest.KafkaClusterId),
                 $"Kafka cluster with id \"{kafkaClusterId}\" is unknown to the system."
             );
-        }
 
-        if (!ModelState.IsValid)
-        {
-            return ValidationProblem();
-        }
+        if (!ModelState.IsValid) return ValidationProblem();
 
-        if (!await _authorizationService.CanAdd(userId, capabilityId, kafkaClusterId))
-        {
-            return Unauthorized();
-        }
+        if (!await _authorizationService.CanAdd(userId, capabilityId, kafkaClusterId)) return Unauthorized();
 
         try
         {
             var topicId = await _capabilityApplicationService.RequestNewTopic(
-                capabilityId: capabilityId,
-                kafkaClusterId: kafkaClusterId,
-                name: kafkaTopicName,
-                description: topicRequest.Description ?? "",
-                partitions: topicPartitions,
-                retention: topicRetention,
-                requestedBy: userId
+                capabilityId,
+                kafkaClusterId,
+                kafkaTopicName,
+                topicRequest.Description ?? "",
+                topicPartitions,
+                topicRetention,
+                userId
             );
 
             var topic = await _kafkaTopicRepository.Get(topicId);
 
             return CreatedAtAction(
-                actionName: "GetTopic",
-                controllerName: "KafkaTopic",
-                routeValues: new { id = topic.Id },
-                value: await _apiResourceFactory.Convert(topic)
+                "GetTopic",
+                "KafkaTopic",
+                new { id = topic.Id },
+                await _apiResourceFactory.Convert(topic)
             );
         }
         catch (EntityAlreadyExistsException err)
         {
-            return Conflict(new ProblemDetails { Title = "Topic already exists", Detail = err.Message, });
+            return Conflict(new ProblemDetails { Title = "Topic already exists", Detail = err.Message });
         }
     }
 
@@ -512,19 +417,16 @@ public class CapabilityController : ControllerBase
     {
         // Verify user and fetch userId
         if (!User.TryGetUserId(out var userId))
-        {
             return Unauthorized(
                 new ProblemDetails
                 {
                     Title = "Unknown user id",
-                    Detail = $"User id is not valid and thus cannot leave any capabilities.",
+                    Detail = "User id is not valid and thus cannot leave any capabilities."
                 }
             );
-        }
 
         // Check that capability with provided id exists
         if (!CapabilityId.TryParse(id, out var capabilityId))
-        {
             return NotFound(
                 new ProblemDetails
                 {
@@ -532,7 +434,6 @@ public class CapabilityController : ControllerBase
                     Detail = $"A capability with id \"{id}\" could not be found."
                 }
             );
-        }
 
         // Leave capability
         try
@@ -558,18 +459,15 @@ public class CapabilityController : ControllerBase
     public async Task<IActionResult> GetKafkaClusterAccessList(string id)
     {
         if (!User.TryGetUserId(out var userId))
-        {
             return Unauthorized(
                 new ProblemDetails
                 {
                     Title = "Unknown user id",
-                    Detail = $"User id is not valid and thus cannot leave any capabilities.",
+                    Detail = "User id is not valid and thus cannot leave any capabilities."
                 }
             );
-        }
 
         if (!CapabilityId.TryParse(id, out var capabilityId))
-        {
             return NotFound(
                 new ProblemDetails
                 {
@@ -577,7 +475,6 @@ public class CapabilityController : ControllerBase
                     Detail = $"A capability with id \"{id}\" could not be found."
                 }
             );
-        }
 
         var clusters = await _kafkaClusterRepository.GetAll();
 
@@ -592,18 +489,15 @@ public class CapabilityController : ControllerBase
     public async Task<IActionResult> GetKafkaClusterAccess(string id, string clusterId)
     {
         if (!User.TryGetUserId(out var userId))
-        {
             return Unauthorized(
                 new ProblemDetails
                 {
                     Title = "Unknown user id",
-                    Detail = $"User id is not valid and thus cannot leave any capabilities.",
+                    Detail = "User id is not valid and thus cannot leave any capabilities."
                 }
             );
-        }
 
         if (!CapabilityId.TryParse(id, out var capabilityId))
-        {
             return NotFound(
                 new ProblemDetails
                 {
@@ -611,10 +505,8 @@ public class CapabilityController : ControllerBase
                     Detail = $"A capability with id \"{id}\" could not be found."
                 }
             );
-        }
 
         if (!KafkaClusterId.TryParse(clusterId, out var kafkaClusterId))
-        {
             return NotFound(
                 new ProblemDetails
                 {
@@ -622,22 +514,18 @@ public class CapabilityController : ControllerBase
                     Detail = $"A Kafka cluster with id \"{clusterId}\" could not be found."
                 }
             );
-        }
 
         if (!await _authorizationService.CanViewAccess(userId, capabilityId))
-        {
             return Unauthorized(
                 new ProblemDetails
                 {
                     Title = "Not a capability member",
-                    Detail = $"User is not a member of capability {capabilityId}",
+                    Detail = $"User is not a member of capability {capabilityId}"
                 }
             );
-        }
 
         var kafkaCluster = await _kafkaClusterRepository.FindBy(kafkaClusterId);
         if (kafkaCluster == null)
-        {
             return NotFound(
                 new ProblemDetails
                 {
@@ -645,11 +533,9 @@ public class CapabilityController : ControllerBase
                     Detail = $"Kafka cluster \"{clusterId}\" could has not found."
                 }
             );
-        }
 
         var clusterAccess = await _kafkaClusterAccessRepository.FindBy(capabilityId, kafkaClusterId);
         if (clusterAccess == null)
-        {
             return NotFound(
                 new ProblemDetails
                 {
@@ -658,24 +544,21 @@ public class CapabilityController : ControllerBase
                         $"Access to Kafka cluster \"{clusterId}\" for capability \"{capabilityId}\" has not been requested."
                 }
             );
-        }
 
         if (clusterAccess.IsAccessGranted)
-        {
             return Ok(
                 new KafkaClusterAccessApiResource(
-                    bootstrapServers: kafkaCluster.BootstrapServers,
-                    schemaRegistryUrl: kafkaCluster.SchemaRegistryUrl,
-                    links: null
+                    kafkaCluster.BootstrapServers,
+                    kafkaCluster.SchemaRegistryUrl,
+                    null
                 )
             );
-        }
 
         return AcceptedAtAction(
-            actionName: nameof(GetCapabilityById),
-            controllerName: "Capability",
-            routeValues: new { id, clusterId },
-            value: new { status = "Requested" }
+            nameof(GetCapabilityById),
+            "Capability",
+            new { id, clusterId },
+            new { status = "Requested" }
         );
     }
 
@@ -686,18 +569,15 @@ public class CapabilityController : ControllerBase
     public async Task<IActionResult> RequestKafkaClusterAccess(string id, string clusterId)
     {
         if (!User.TryGetUserId(out var userId))
-        {
             return Unauthorized(
                 new ProblemDetails
                 {
                     Title = "Unknown user id",
-                    Detail = $"User id is not valid and thus cannot leave any capabilities.",
+                    Detail = "User id is not valid and thus cannot leave any capabilities."
                 }
             );
-        }
 
         if (!CapabilityId.TryParse(id, out var capabilityId))
-        {
             return NotFound(
                 new ProblemDetails
                 {
@@ -705,10 +585,8 @@ public class CapabilityController : ControllerBase
                     Detail = $"A capability with id \"{id}\" could not be found."
                 }
             );
-        }
 
         if (!KafkaClusterId.TryParse(clusterId, out var kafkaClusterId))
-        {
             return NotFound(
                 new ProblemDetails
                 {
@@ -716,15 +594,14 @@ public class CapabilityController : ControllerBase
                     Detail = $"A Kafka cluster with id \"{clusterId}\" could not be found."
                 }
             );
-        }
 
         await _capabilityApplicationService.RequestKafkaClusterAccess(capabilityId, kafkaClusterId, userId);
 
         return AcceptedAtAction(
-            actionName: nameof(GetCapabilityById),
-            controllerName: "Capability",
-            routeValues: new { id, clusterId },
-            value: new { status = "Requested" }
+            nameof(GetCapabilityById),
+            "Capability",
+            new { id, clusterId },
+            new { status = "Requested" }
         );
     }
 
@@ -736,18 +613,15 @@ public class CapabilityController : ControllerBase
     {
         // Verify user and fetch userId
         if (!User.TryGetUserId(out var userId))
-        {
             return Unauthorized(
                 new ProblemDetails
                 {
                     Title = "Unknown user id",
-                    Detail = $"User id is not valid and thus cannot leave any capabilities.",
+                    Detail = "User id is not valid and thus cannot leave any capabilities."
                 }
             );
-        }
-        
+
         if (!CapabilityId.TryParse(id, out var capabilityId))
-        {
             return NotFound(
                 new ProblemDetails
                 {
@@ -755,12 +629,10 @@ public class CapabilityController : ControllerBase
                     Detail = $"A capability with id \"{id}\" could not be found."
                 }
             );
-        }
 
         // deleting and canceling deletion are the same responsibility currently.
         // thus we use the same authorization check for both
         if (!await _authorizationService.CanDeleteCapability(userId, capabilityId))
-        {
             return Unauthorized(
                 new ProblemDetails
                 {
@@ -769,7 +641,6 @@ public class CapabilityController : ControllerBase
                         $"User \"{userId}\" is not authorized to cancel deletion request for capability \"{capabilityId}\"."
                 }
             );
-        }
 
         // Set capability status
         try
@@ -799,18 +670,15 @@ public class CapabilityController : ControllerBase
     {
         // Verify user and fetch userId
         if (!User.TryGetUserId(out var userId))
-        {
             return Unauthorized(
                 new ProblemDetails
                 {
                     Title = "Unknown user id",
-                    Detail = $"User id is not valid and thus cannot leave any capabilities.",
+                    Detail = "User id is not valid and thus cannot leave any capabilities."
                 }
             );
-        }
-        
+
         if (!CapabilityId.TryParse(id, out var capabilityId))
-        {
             return NotFound(
                 new ProblemDetails
                 {
@@ -818,12 +686,10 @@ public class CapabilityController : ControllerBase
                     Detail = $"A capability with id \"{id}\" could not be found."
                 }
             );
-        }
 
         // deleting and canceling deletion are the same responsibility currently.
         // thus we use the same authorization check for both -- if you can do one, you can do the other
         if (!await _authorizationService.CanDeleteCapability(userId, capabilityId))
-        {
             return Unauthorized(
                 new ProblemDetails
                 {
@@ -832,7 +698,6 @@ public class CapabilityController : ControllerBase
                         $"User \"{userId}\" is not authorized to cancel deletion request for capability \"{capabilityId}\"."
                 }
             );
-        }
 
         // Set capability status
         try
@@ -861,9 +726,7 @@ public class CapabilityController : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound, "application/problem+json")]
     public async Task<IActionResult> GetCapabilityMetadata(string id)
     {
-
         if (!CapabilityId.TryParse(id, out var capabilityId))
-        {
             return NotFound(
                 new ProblemDetails
                 {
@@ -871,7 +734,6 @@ public class CapabilityController : ControllerBase
                     Detail = $"A capability with id \"{id}\" could not be found."
                 }
             );
-        }
 
         var metadata = await _capabilityApplicationService.GetJsonMetadata(capabilityId);
         return Ok(metadata);
@@ -886,18 +748,15 @@ public class CapabilityController : ControllerBase
     {
         // Verify user and fetch userId
         if (!User.TryGetUserId(out var userId))
-        {
             return Unauthorized(
                 new ProblemDetails
                 {
                     Title = "Unknown user id",
-                    Detail = $"User id is not valid and thus set capability metadata.",
+                    Detail = "User id is not valid and thus set capability metadata."
                 }
             );
-        }
-        
+
         if (!CapabilityId.TryParse(id, out var capabilityId))
-        {
             return NotFound(
                 new ProblemDetails
                 {
@@ -905,11 +764,9 @@ public class CapabilityController : ControllerBase
                     Detail = $"A capability with id \"{id}\" could not be found."
                 }
             );
-        }
 
         var portalUser = HttpContext.User.ToPortalUser();
         if (!_authorizationService.CanSetCapabilityJsonMetadata(portalUser))
-        {
             return Unauthorized(
                 new ProblemDetails
                 {
@@ -917,10 +774,8 @@ public class CapabilityController : ControllerBase
                     Detail = $"User \"{userId}\" is not authorized to set capability metadata."
                 }
             );
-        }
 
         if (request?.JsonMetadata == null)
-        {
             return BadRequest(
                 new ProblemDetails
                 {
@@ -929,7 +784,6 @@ public class CapabilityController : ControllerBase
                     Status = StatusCodes.Status400BadRequest
                 }
             );
-        }
 
         try
         {
@@ -956,27 +810,23 @@ public class CapabilityController : ControllerBase
         return Ok();
     }
 
-    [HttpPost("{id}/adduser")]
+    [HttpPost("{id}/join")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest, "application/problem+json")]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized, "application/problem+json")]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound, "application/problem+json")]
     public async Task<IActionResult> AddUserToCapability(string id)
     {
-
         if (!User.TryGetUserId(out var userId))
-        {
             return Unauthorized(
                 new ProblemDetails
                 {
                     Title = "Unknown user id",
-                    Detail = $"User id is not valid and thus set capability metadata.",
+                    Detail = "User id is not valid and thus set capability metadata."
                 }
             );
-        }
 
         if (!CapabilityId.TryParse(id, out var capabilityId))
-        {
             return NotFound(
                 new ProblemDetails
                 {
@@ -984,13 +834,19 @@ public class CapabilityController : ControllerBase
                     Detail = $"A capability with id \"{id}\" could not be found."
                 }
             );
-        }
         var portalUser = HttpContext.User.ToPortalUser();
         if (_authorizationService.CanBypassMembershipApprovals(portalUser))
         {
-            await _membershipApplicationService.AddUserToCapability(capabilityId, userId);
+            await _membershipApplicationService.AddUserToCapability(id, portalUser.Id);
+            return Ok();
         }
 
-        return Ok();
+        return Unauthorized(
+            new ProblemDetails
+            {
+                Title = "User unauthorized",
+                Detail = $"user \"{userId}\" isn't authorized to join capabilities directly."
+            }
+        );
     }
 }

--- a/src/SelfService/Infrastructure/Api/Capabilities/CapabilityController.cs
+++ b/src/SelfService/Infrastructure/Api/Capabilities/CapabilityController.cs
@@ -745,8 +745,7 @@ public class CapabilityController : ControllerBase
                 }
             );
         }
-
-        // Check that capability with provided id exists
+        
         if (!CapabilityId.TryParse(id, out var capabilityId))
         {
             return NotFound(
@@ -809,8 +808,7 @@ public class CapabilityController : ControllerBase
                 }
             );
         }
-
-        // Check that capability with provided id exists
+        
         if (!CapabilityId.TryParse(id, out var capabilityId))
         {
             return NotFound(
@@ -863,7 +861,7 @@ public class CapabilityController : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound, "application/problem+json")]
     public async Task<IActionResult> GetCapabilityMetadata(string id)
     {
-        // Check that capability with provided id exists
+
         if (!CapabilityId.TryParse(id, out var capabilityId))
         {
             return NotFound(
@@ -897,8 +895,7 @@ public class CapabilityController : ControllerBase
                 }
             );
         }
-
-        // Check that capability with provided id exists
+        
         if (!CapabilityId.TryParse(id, out var capabilityId))
         {
             return NotFound(
@@ -954,6 +951,44 @@ public class CapabilityController : ControllerBase
             return CustomObjectResult.InternalServerError(
                 new ProblemDetails { Title = "Uncaught Exception", Detail = $"SetCapabilityMetadata: {e.Message}." }
             );
+        }
+
+        return Ok();
+    }
+
+    [HttpPost("{id}/adduser")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest, "application/problem+json")]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized, "application/problem+json")]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound, "application/problem+json")]
+    public async Task<IActionResult> AddUserToCapability(string id)
+    {
+
+        if (!User.TryGetUserId(out var userId))
+        {
+            return Unauthorized(
+                new ProblemDetails
+                {
+                    Title = "Unknown user id",
+                    Detail = $"User id is not valid and thus set capability metadata.",
+                }
+            );
+        }
+
+        if (!CapabilityId.TryParse(id, out var capabilityId))
+        {
+            return NotFound(
+                new ProblemDetails
+                {
+                    Title = "Capability not found.",
+                    Detail = $"A capability with id \"{id}\" could not be found."
+                }
+            );
+        }
+        var portalUser = HttpContext.User.ToPortalUser();
+        if (_authorizationService.CanBypassMembershipApprovals(portalUser))
+        {
+            await _membershipApplicationService.AddUserToCapability(capabilityId, userId);
         }
 
         return Ok();

--- a/src/SelfService/Infrastructure/Api/Capabilities/CapabilityController.cs
+++ b/src/SelfService/Infrastructure/Api/Capabilities/CapabilityController.cs
@@ -74,7 +74,8 @@ public class CapabilityController : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict, "application/problem+json")]
     public async Task<IActionResult> CreateNewCapability([FromBody] NewCapabilityRequest request)
     {
-        if (!User.TryGetUserId(out var userId)) return Unauthorized();
+        if (!User.TryGetUserId(out var userId))
+            return Unauthorized();
 
         if (!CapabilityId.TryCreateFrom(request.Name, out var capabilityId))
             ModelState.AddModelError(
@@ -82,7 +83,8 @@ public class CapabilityController : ControllerBase
                 $"unable to create capability ID from name \"{request.Name}\""
             );
 
-        if (!ModelState.IsValid) return ValidationProblem();
+        if (!ModelState.IsValid)
+            return ValidationProblem();
 
         // See if request has valid json metadata
         var jsonMetadataResult = await _selfServiceJsonSchemaService.ValidateJsonMetadata(
@@ -188,7 +190,8 @@ public class CapabilityController : ControllerBase
         if (!CapabilityId.TryParse(id, out var capabilityId))
             ModelState.AddModelError(nameof(id), $"Value \"{id}\" is not a valid capability id.");
 
-        if (!ModelState.IsValid) return ValidationProblem();
+        if (!ModelState.IsValid)
+            return ValidationProblem();
 
         var members = await _membersQuery.FindBy(capabilityId);
 
@@ -201,16 +204,21 @@ public class CapabilityController : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound, "application/problem+json")]
     public async Task<IActionResult> GetCapabilityAwsAccount(string id)
     {
-        if (!User.TryGetUserId(out var userId)) return Unauthorized();
+        if (!User.TryGetUserId(out var userId))
+            return Unauthorized();
 
-        if (!CapabilityId.TryParse(id, out var capabilityId)) return NotFound();
+        if (!CapabilityId.TryParse(id, out var capabilityId))
+            return NotFound();
 
-        if (!await _capabilityRepository.Exists(capabilityId)) return NotFound();
+        if (!await _capabilityRepository.Exists(capabilityId))
+            return NotFound();
 
-        if (!await _authorizationService.CanViewAwsAccount(userId, capabilityId)) return Unauthorized();
+        if (!await _authorizationService.CanViewAwsAccount(userId, capabilityId))
+            return Unauthorized();
 
         var account = await _awsAccountRepository.FindBy(capabilityId);
-        if (account is null) return NotFound();
+        if (account is null)
+            return NotFound();
 
         return Ok(await _apiResourceFactory.Convert(account));
     }
@@ -222,13 +230,17 @@ public class CapabilityController : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict, "application/problem+json")]
     public async Task<IActionResult> RequestAwsAccount(string id, [FromServices] SelfServiceDbContext dbContext)
     {
-        if (!User.TryGetUserId(out var userId)) return Unauthorized();
+        if (!User.TryGetUserId(out var userId))
+            return Unauthorized();
 
-        if (!CapabilityId.TryParse(id, out var capabilityId)) return NotFound();
+        if (!CapabilityId.TryParse(id, out var capabilityId))
+            return NotFound();
 
-        if (!await _capabilityRepository.Exists(capabilityId)) return NotFound();
+        if (!await _capabilityRepository.Exists(capabilityId))
+            return NotFound();
 
-        if (!await _authorizationService.CanRequestAwsAccount(userId, capabilityId)) return Unauthorized();
+        if (!await _authorizationService.CanRequestAwsAccount(userId, capabilityId))
+            return Unauthorized();
 
         try
         {
@@ -253,11 +265,14 @@ public class CapabilityController : ControllerBase
         [FromServices] ICapabilityMembershipApplicationQuery query
     )
     {
-        if (!User.TryGetUserId(out var userId)) return Unauthorized();
+        if (!User.TryGetUserId(out var userId))
+            return Unauthorized();
 
-        if (!CapabilityId.TryParse(id, out var capabilityId)) return NotFound();
+        if (!CapabilityId.TryParse(id, out var capabilityId))
+            return NotFound();
 
-        if (!await _capabilityRepository.Exists(capabilityId)) return NotFound();
+        if (!await _capabilityRepository.Exists(capabilityId))
+            return NotFound();
 
         var applications = await query.FindPendingBy(capabilityId);
 
@@ -282,11 +297,14 @@ public class CapabilityController : ControllerBase
         [FromServices] IMembershipApplicationRepository membershipApplicationRepository
     )
     {
-        if (!User.TryGetUserId(out var userId)) return Unauthorized();
+        if (!User.TryGetUserId(out var userId))
+            return Unauthorized();
 
-        if (!CapabilityId.TryParse(id, out var capabilityId)) return NotFound();
+        if (!CapabilityId.TryParse(id, out var capabilityId))
+            return NotFound();
 
-        if (!await _capabilityRepository.Exists(capabilityId)) return NotFound();
+        if (!await _capabilityRepository.Exists(capabilityId))
+            return NotFound();
 
         try
         {
@@ -342,11 +360,14 @@ public class CapabilityController : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict, "application/problem+json")]
     public async Task<IActionResult> AddCapabilityTopic(string id, [FromBody] NewKafkaTopicRequest topicRequest)
     {
-        if (!User.TryGetUserId(out var userId)) return Unauthorized();
+        if (!User.TryGetUserId(out var userId))
+            return Unauthorized();
 
-        if (!CapabilityId.TryParse(id, out var capabilityId)) return NotFound();
+        if (!CapabilityId.TryParse(id, out var capabilityId))
+            return NotFound();
 
-        if (!await _capabilityRepository.Exists(capabilityId)) return NotFound();
+        if (!await _capabilityRepository.Exists(capabilityId))
+            return NotFound();
 
         if (!KafkaClusterId.TryParse(topicRequest.KafkaClusterId, out var kafkaClusterId))
             ModelState.AddModelError(
@@ -378,9 +399,11 @@ public class CapabilityController : ControllerBase
                 $"Kafka cluster with id \"{kafkaClusterId}\" is unknown to the system."
             );
 
-        if (!ModelState.IsValid) return ValidationProblem();
+        if (!ModelState.IsValid)
+            return ValidationProblem();
 
-        if (!await _authorizationService.CanAdd(userId, capabilityId, kafkaClusterId)) return Unauthorized();
+        if (!await _authorizationService.CanAdd(userId, capabilityId, kafkaClusterId))
+            return Unauthorized();
 
         try
         {
@@ -547,11 +570,7 @@ public class CapabilityController : ControllerBase
 
         if (clusterAccess.IsAccessGranted)
             return Ok(
-                new KafkaClusterAccessApiResource(
-                    kafkaCluster.BootstrapServers,
-                    kafkaCluster.SchemaRegistryUrl,
-                    null
-                )
+                new KafkaClusterAccessApiResource(kafkaCluster.BootstrapServers, kafkaCluster.SchemaRegistryUrl, null)
             );
 
         return AcceptedAtAction(

--- a/src/SelfService/Infrastructure/Persistence/MembershipRepository.cs
+++ b/src/SelfService/Infrastructure/Persistence/MembershipRepository.cs
@@ -23,6 +23,12 @@ public class MembershipRepository : IMembershipRepository
         return await _dbContext.Memberships.Where(x => x.CapabilityId == capabilityId).ToListAsync();
     }
 
+    public async Task<bool> IsAlreadyMember(CapabilityId capabilityId, UserId userId)
+    {
+        var count = await _dbContext.Memberships.Where(x => x.CapabilityId == capabilityId && x.UserId == userId).CountAsync();
+        return (count > 0);
+    }
+
     public async Task<Membership?> CancelWithCapabilityId(CapabilityId capabilityId, UserId userId)
     {
         var membershipCount = await _dbContext.Memberships.Where(x => x.CapabilityId == capabilityId).CountAsync();


### PR DESCRIPTION
closes dfds/cloudplatform/issues/2173

# Additional Review Notes
This PR covers a bit more than just the issue:
- there was no tests/checks that a duplicate membership could be created, so these were added. This required adding functions to some interfaces, and creating everything necessary for a `MembershipApplicationService` to be tested.
- the code relevant to the [issue](dfds/cloudplatform/issues/2173) is the `/join`endpoint in capability controllers + the corresponding functionality in `MembershipApplicationService.cs` 