### PR TITLE
Follow our linking strategy

### DIFF
--- a/src/SelfService/Infrastructure/Api/ApiResourceFactory.cs
+++ b/src/SelfService/Infrastructure/Api/ApiResourceFactory.cs
@@ -919,6 +919,18 @@ public class ApiResourceFactory
                     ) ?? "",
                     rel: "related",
                     allow: Allow.Get
+                ),
+                invitationsLinks: new MyProfileApiResource.InvitationsLinks(
+                    cabalityInvitations: new ResourceLink(
+                        href: _linkGenerator.GetUriByAction(
+                            httpContext: HttpContext,
+                            controller: GetNameOf<InvitationController>(),
+                            action: nameof(InvitationController.GetActiveInvitations),
+                            values: new { targetType = "Capability" }
+                        ) ?? "",
+                        rel: "related",
+                        allow: Allow.Get
+                    )
                 )
             )
         );

--- a/src/SelfService/Infrastructure/Api/Me/Module.cs
+++ b/src/SelfService/Infrastructure/Api/Me/Module.cs
@@ -137,18 +137,31 @@ public class MyProfileApiResource
         public ResourceLink PersonalInformation { get; set; }
         public ResourceLink PortalVisits { get; set; }
         public ResourceLink TopVisitors { get; set; }
+        public InvitationsLinks InvitationsLinks { get; set; }
 
         public MyProfileLinks(
             ResourceLink self,
             ResourceLink personalInformation,
             ResourceLink portalVisits,
-            ResourceLink topVisitors
+            ResourceLink topVisitors,
+            InvitationsLinks invitationsLinks
         )
         {
             Self = self;
             PersonalInformation = personalInformation;
             PortalVisits = portalVisits;
             TopVisitors = topVisitors;
+            InvitationsLinks = invitationsLinks;
+        }
+    }
+
+    public class InvitationsLinks
+    {
+        public ResourceLink CapabilityInvitations { get; set; }
+
+        public InvitationsLinks(ResourceLink cabalityInvitations)
+        {
+            CapabilityInvitations = cabalityInvitations;
         }
     }
 


### PR DESCRIPTION
related to dfds/cloudplatform/issues/2231

# Additional Review Notes
 I had hoped we could avoid linking here, for there is no good spot for it.
 It turned out that the non-linking solution was uglier and forced a lot of responsibility unto the frontend so I went back on that desire.
As long as we use _links, then we should at least also be consistent.

This version is easy to expand with future invitation types, so there is that at least.
That is also why it lives on the profile.
