### PR TITLE
Separate reading and writing permission for AWS Accounts.

### DIFF
--- a/src/SelfService/Domain/Services/AuthorizationService.cs
+++ b/src/SelfService/Domain/Services/AuthorizationService.cs
@@ -151,7 +151,8 @@ public class AuthorizationService : IAuthorizationService
 
     public async Task<bool> CanViewAwsAccount(UserId userId, CapabilityId capabilityId)
     {
-        return await _membershipQuery.HasActiveMembership(userId, capabilityId);
+        return await _membershipQuery.HasActiveMembership(userId, capabilityId)
+            && await _awsAccountRepository.Exists(capabilityId);
     }
 
     public async Task<bool> CanRequestAwsAccount(UserId userId, CapabilityId capabilityId)

--- a/src/SelfService/Infrastructure/Api/ApiResourceFactory.cs
+++ b/src/SelfService/Infrastructure/Api/ApiResourceFactory.cs
@@ -432,11 +432,11 @@ public class ApiResourceFactory
         if (await _authorizationService.CanViewAwsAccount(CurrentUser, capability.Id))
         {
             allowedInteractions += Get;
+        }
 
-            if (await _authorizationService.CanRequestAwsAccount(CurrentUser, capability.Id))
-            {
-                allowedInteractions += Post;
-            }
+        if (await _authorizationService.CanRequestAwsAccount(CurrentUser, capability.Id))
+        {
+            allowedInteractions += Post;
         }
 
         return new ResourceLink(


### PR DESCRIPTION
relates dfds/cloudplatform/issues/2253
(Backend part of issue 2253)

# Additional Review Notes
I am unsure if this separation has additional effects elsewhere.
I believe it should be good.

Checking for account existence before allowing read seems like a no brainer.