### PR TITLE
Prevent multiple invitations and existing invitations

### DIFF
--- a/db/seed/Invitation.csv
+++ b/db/seed/Invitation.csv
@@ -1,5 +1,7 @@
 Id;Invitee;Description;TargetId;TargetType;Status;CreatedBy;CreatedAt;ModifiedAt
-633564a4-ebe1-41df-800f-e256c4fa5000;andfris@dfds.com;Join this delightful Capability;notmycapability-xx1;Capability;Active;SeedScript;2023-10-23T00:08:00;2023-10-23T08:00:00
-633564a4-ebe1-41df-800f-e256c4fa5001;andfris@dfds.com;Join this delightful Capability;notmycapability-xx2;Capability;Active;SeedScript;2023-10-23T00:08:00;2023-10-23T08:00:00
-633564a4-ebe1-41df-800f-e256c4fa5002;andfris@dfds.com;Join this delightful Capability;notmycapability-xx3;Capability;Declined;SeedScript;2023-10-23T00:08:00;2023-10-23T08:00:00
-633564a4-ebe1-41df-800f-e256c4fa5003;someoneunknown@dfds.com;Join this delightful Capability;notmycapability-xx2;Capability;Active;SeedScript;2023-10-23T00:08:00;2023-10-23T08:00:00
+633564a4-ebe1-41df-800f-e256c4fa5000;andfris@dfds.com;Join this delightful Capability (1);notmycapability-xx1;Capability;Active;SeedScript;2023-10-23T00:08:00;2023-10-23T08:00:00
+633564a4-ebe1-41df-800f-e256c4fa5010;andfris@dfds.com;Join this delightful Capability (1);notmycapability-xx1;Capability;Active;SeedScript;2023-10-23T00:08:00;2023-10-23T08:00:00
+633564a4-ebe1-41df-800f-e256c4fa5020;andfris@dfds.com;Join this delightful Capability (1);notmycapability-xx1;Capability;Active;SeedScript;2023-10-23T00:08:00;2023-10-23T08:00:00
+633564a4-ebe1-41df-800f-e256c4fa5001;andfris@dfds.com;Join this delightful Capability (2);notmycapability-xx2;Capability;Active;SeedScript;2023-10-23T00:08:00;2023-10-23T08:00:00
+633564a4-ebe1-41df-800f-e256c4fa5002;andfris@dfds.com;Join this delightful Capability (3);notmycapability-xx3;Capability;Declined;SeedScript;2023-10-23T00:08:00;2023-10-23T08:00:00
+633564a4-ebe1-41df-800f-e256c4fa5003;someoneunknown@dfds.com;Join this delightful Capability (2);notmycapability-xx2;Capability;Active;SeedScript;2023-10-23T00:08:00;2023-10-23T08:00:00

--- a/src/SelfService.Tests/Application/TestInvitationApplicationService.cs
+++ b/src/SelfService.Tests/Application/TestInvitationApplicationService.cs
@@ -39,6 +39,77 @@ public class TestInvitationApplicationService
     }
 
     [Fact]
+    public async Task silently_ignore_identical_simultaneous_invitations()
+    {
+        var databaseFactory = new InMemoryDatabaseFactory();
+        var dbContext = await databaseFactory.CreateSelfServiceDbContext();
+
+        var capabilityRepo = A.CapabilityRepository.WithDbContext(dbContext).Build();
+
+        var invitationRepo = A.InvitationRepository.WithDbContext(dbContext).Build();
+        var invitationService = A.InvitationApplicationService
+            .WithDbContextAndDefaultRepositories(dbContext)
+            .WithInvitationRepository(invitationRepo)
+            .Build();
+
+        var testCapability = A.Capability.Build();
+        await capabilityRepo.Add(testCapability);
+        await dbContext.SaveChangesAsync();
+
+        List<string> dummyInvitees = new() { dummyInvitee1, dummyInvitee2, dummyInvitee1 };
+
+        await invitationService.CreateCapabilityInvitations(dummyInvitees, dummyInviterId, testCapability);
+        await dbContext.SaveChangesAsync();
+
+        var invitations = await invitationRepo.GetAllWithPredicate(
+            x => x.TargetId == testCapability.Id && x.TargetType == InvitationTargetTypeOptions.Capability
+        );
+        Assert.Equal(2, invitations.Count);
+    }
+
+    [Fact]
+    public async Task ignore_adding_identical_invitation()
+    {
+        var databaseFactory = new InMemoryDatabaseFactory();
+        var dbContext = await databaseFactory.CreateSelfServiceDbContext();
+
+        var capabilityRepo = A.CapabilityRepository.WithDbContext(dbContext).Build();
+
+        var invitationRepo = A.InvitationRepository.WithDbContext(dbContext).Build();
+        var invitationService = A.InvitationApplicationService
+            .WithDbContextAndDefaultRepositories(dbContext)
+            .WithInvitationRepository(invitationRepo)
+            .Build();
+
+        var testCapability = A.Capability.Build();
+        await capabilityRepo.Add(testCapability);
+        await dbContext.SaveChangesAsync();
+
+        List<string> dummyInvitees;
+        List<Invitation> invitations;
+
+        dummyInvitees = new() { dummyInvitee1, dummyInvitee2 };
+
+        await invitationService.CreateCapabilityInvitations(dummyInvitees, dummyInviterId, testCapability);
+        await dbContext.SaveChangesAsync();
+
+        invitations = await invitationRepo.GetAllWithPredicate(
+            x => x.TargetId == testCapability.Id && x.TargetType == InvitationTargetTypeOptions.Capability
+        );
+        Assert.Equal(2, invitations.Count);
+
+        dummyInvitees = new() { dummyInvitee1, dummyInvitee2 };
+
+        await invitationService.CreateCapabilityInvitations(dummyInvitees, dummyInviterId, testCapability);
+        await dbContext.SaveChangesAsync();
+
+        invitations = await invitationRepo.GetAllWithPredicate(
+            x => x.TargetId == testCapability.Id && x.TargetType == InvitationTargetTypeOptions.Capability
+        );
+        Assert.Equal(2, invitations.Count);
+    }
+
+    [Fact]
     public async Task get_active_invitations_for_user_and_type()
     {
         var databaseFactory = new InMemoryDatabaseFactory();

--- a/src/SelfService.Tests/Application/TestMembershipApplicationService.cs
+++ b/src/SelfService.Tests/Application/TestMembershipApplicationService.cs
@@ -20,8 +20,10 @@ public class TestMembershipApplicationService
         UserId userId = "chungus@dfds.com";
         CapabilityId capabilityId = "reflect2improve-GPU-cluster-mgmt-qxyz";
         var membershipRepo = A.MembershipRepository.WithDbContext(dbContext).Build();
+        var invitationRepo = A.InvitationRepository.WithDbContext(dbContext).Build();
         var membershipApplicationService = A.MembershipApplicationService
             .WithMembershipRepository(membershipRepo)
+            .WithInvitationRepository(invitationRepo)
             .Build();
 
         await membershipApplicationService.AddCreatorAsInitialMember(capabilityId, userId);
@@ -45,8 +47,10 @@ public class TestMembershipApplicationService
         UserId userId = "chungus@dfds.com";
         CapabilityId capabilityId = "reflect2improve-GPU-cluster-mgmt-qxyz";
         var membershipRepo = A.MembershipRepository.WithDbContext(dbContext).Build();
+        var invitationRepo = A.InvitationRepository.WithDbContext(dbContext).Build();
         var membershipApplicationService = A.MembershipApplicationService
             .WithMembershipRepository(membershipRepo)
+            .WithInvitationRepository(invitationRepo)
             .Build();
 
         await membershipApplicationService.JoinCapability(capabilityId, userId);

--- a/src/SelfService.Tests/Builders/MembershipApplicationServiceBuilder.cs
+++ b/src/SelfService.Tests/Builders/MembershipApplicationServiceBuilder.cs
@@ -15,6 +15,7 @@ public class MembershipApplicationServiceBuilder
     private IMembershipApplicationRepository _membershipApplicationRepository;
     private ICapabilityRepository _capabilityRepository;
     private IAuthorizationService _authorizationService;
+    private IInvitationRepository _invitationRepository;
 
     public MembershipApplicationServiceBuilder()
     {
@@ -22,6 +23,7 @@ public class MembershipApplicationServiceBuilder
         _membershipRepository = Dummy.Of<IMembershipRepository>();
         _capabilityRepository = Dummy.Of<ICapabilityRepository>();
         _authorizationService = Dummy.Of<IAuthorizationService>();
+        _invitationRepository = Dummy.Of<IInvitationRepository>();
     }
 
     public MembershipApplicationServiceBuilder WithMembershipRepository(IMembershipRepository membershipRepository)
@@ -50,6 +52,12 @@ public class MembershipApplicationServiceBuilder
         return this;
     }
 
+    public MembershipApplicationServiceBuilder WithInvitationRepository(IInvitationRepository invitationRepository)
+    {
+        _invitationRepository = invitationRepository;
+        return this;
+    }
+
     public MembershipApplicationService Build()
     {
         return new MembershipApplicationService(
@@ -60,7 +68,8 @@ public class MembershipApplicationServiceBuilder
             authorizationService: _authorizationService,
             systemTime: SystemTime.Default,
             membershipQuery: Mock.Of<IMembershipQuery>(),
-            membershipApplicationDomainService: Mock.Of<IMembershipApplicationDomainService>()
+            membershipApplicationDomainService: Mock.Of<IMembershipApplicationDomainService>(),
+            invitationRepository: _invitationRepository
         );
     }
 

--- a/src/SelfService/Application/IMembershipApplicationService.cs
+++ b/src/SelfService/Application/IMembershipApplicationService.cs
@@ -4,7 +4,7 @@ namespace SelfService.Application;
 
 public interface IMembershipApplicationService
 {
-    Task<MembershipId> AcceptApplication(MembershipApplicationId applicationId);
+    Task AcceptApplication(MembershipApplicationId applicationId);
     Task<MembershipApplicationId> SubmitMembershipApplication(CapabilityId capabilityId, UserId userId);
     Task CancelExpiredMembershipApplications();
     Task TryFinalizeMembershipApplication(MembershipApplicationId applicationId);

--- a/src/SelfService/Application/InvitationApplicationService.cs
+++ b/src/SelfService/Application/InvitationApplicationService.cs
@@ -160,7 +160,8 @@ public class InvitationApplicationService : IInvitationApplicationService
     {
         var description = $"\"{inviter}\" has invited you to join capability \"{capability.Name}\"";
         var invitations = new List<Invitation>();
-        foreach (var invitee in invitees)
+        var dedupedInvitees = invitees.Distinct().ToList();
+        foreach (var invitee in dedupedInvitees)
         {
             if (!UserId.TryParse(invitee, out var inviteeId))
             {
@@ -191,7 +192,7 @@ public class InvitationApplicationService : IInvitationApplicationService
             var invitation = await CreateInvitation(
                 invitee: inviteeId,
                 description: description,
-                targetId: capability.Id.ToString(),
+                targetId: capability.Id,
                 targetType: InvitationTargetTypeOptions.Capability,
                 createdBy: inviter
             );

--- a/src/SelfService/Application/InvitationApplicationService.cs
+++ b/src/SelfService/Application/InvitationApplicationService.cs
@@ -109,11 +109,10 @@ public class InvitationApplicationService : IInvitationApplicationService
             }
 
             // cancel all similar invitations
-            var similarInvitations = await _invitationRepository.GetAllWithPredicate(
-                x =>
-                    x.Invitee == invitation.Invitee
-                    && x.TargetId == invitation.TargetId
-                    && x.Status == InvitationStatusOptions.Active
+            var similarInvitations = await _invitationRepository.GetOtherActiveInvitationsForSameTarget(
+                invitation.Invitee,
+                invitation.TargetId,
+                invitation.Id
             );
             foreach (var i in similarInvitations)
             {
@@ -178,9 +177,7 @@ public class InvitationApplicationService : IInvitationApplicationService
                 );
                 continue;
             }
-            var existingInvitations = await _invitationRepository.GetAllWithPredicate(
-                x => x.Invitee == invitee && x.TargetId == capability.Id && x.Status == InvitationStatusOptions.Active
-            );
+            var existingInvitations = await _invitationRepository.GetActiveInvitations(inviteeId, capability.Id);
             if (existingInvitations.Any())
             {
                 _logger.LogWarning(

--- a/src/SelfService/Application/MembershipApplicationService.cs
+++ b/src/SelfService/Application/MembershipApplicationService.cs
@@ -44,10 +44,8 @@ public class MembershipApplicationService : IMembershipApplicationService
     private async Task CreateAndAddMembership(CapabilityId capabilityId, UserId userId)
     {
         // Note: requires [TransactionalBoundary], which should be wrapped elsewhere
-        var invitation = await _invitationRepository.FindByPredicate(
-            x => x.Invitee == userId && x.TargetId == capabilityId
-        );
-        if (invitation != null)
+        var existingInvitations = await _invitationRepository.GetActiveInvitations(userId, capabilityId);
+        foreach (var invitation in existingInvitations)
         {
             invitation.Cancel();
         }

--- a/src/SelfService/Application/MembershipApplicationService.cs
+++ b/src/SelfService/Application/MembershipApplicationService.cs
@@ -16,6 +16,7 @@ public class MembershipApplicationService : IMembershipApplicationService
     private readonly SystemTime _systemTime;
     private readonly IMembershipQuery _membershipQuery;
     private readonly IMembershipApplicationDomainService _membershipApplicationDomainService;
+    private readonly IInvitationRepository _invitationRepository;
 
     public MembershipApplicationService(
         ILogger<MembershipApplicationService> logger,
@@ -25,7 +26,8 @@ public class MembershipApplicationService : IMembershipApplicationService
         IAuthorizationService authorizationService,
         SystemTime systemTime,
         IMembershipQuery membershipQuery,
-        IMembershipApplicationDomainService membershipApplicationDomainService
+        IMembershipApplicationDomainService membershipApplicationDomainService,
+        IInvitationRepository invitationRepository
     )
     {
         _logger = logger;
@@ -36,10 +38,20 @@ public class MembershipApplicationService : IMembershipApplicationService
         _systemTime = systemTime;
         _membershipQuery = membershipQuery;
         _membershipApplicationDomainService = membershipApplicationDomainService;
+        _invitationRepository = invitationRepository;
     }
 
     private async Task CreateAndAddMembership(CapabilityId capabilityId, UserId userId)
     {
+        // Note: requires [TransactionalBoundary], which should be wrapped elsewhere
+        var invitation = await _invitationRepository.FindByPredicate(
+            x => x.Invitee == userId && x.TargetId == capabilityId
+        );
+        if (invitation != null)
+        {
+            invitation.Cancel();
+        }
+
         if (await _membershipRepository.IsAlreadyMember(capabilityId, userId))
         {
             throw new AlreadyHasActiveMembershipException(
@@ -69,7 +81,7 @@ public class MembershipApplicationService : IMembershipApplicationService
     }
 
     [TransactionalBoundary, Outboxed]
-    public async Task<MembershipId> AcceptApplication(MembershipApplicationId applicationId)
+    public async Task AcceptApplication(MembershipApplicationId applicationId)
     {
         using var _ = _logger.BeginScope(
             "{Action} on {ImplementationType}",
@@ -97,14 +109,7 @@ public class MembershipApplicationService : IMembershipApplicationService
             throw EntityNotFoundException<Capability>.UsingId(membershipApplication.CapabilityId);
         }
 
-        var newMembership = Membership.CreateFor(
-            capabilityId: membershipApplication.CapabilityId,
-            userId: membershipApplication.Applicant,
-            createdAt: _systemTime.Now
-        );
-
         await CreateAndAddMembership(membershipApplication.CapabilityId, membershipApplication.Applicant);
-        return newMembership.Id;
     }
 
     [TransactionalBoundary, Outboxed]

--- a/src/SelfService/Domain/Models/IInvitationRepository.cs
+++ b/src/SelfService/Domain/Models/IInvitationRepository.cs
@@ -1,3 +1,11 @@
 namespace SelfService.Domain.Models;
 
-public interface IInvitationRepository : IGenericRepository<Invitation, InvitationId> { }
+public interface IInvitationRepository : IGenericRepository<Invitation, InvitationId>
+{
+    Task<List<Invitation>> GetActiveInvitations(UserId userId, string targetId);
+    Task<List<Invitation>> GetOtherActiveInvitationsForSameTarget(
+        UserId userId,
+        string targetId,
+        InvitationId invitationId
+    );
+}

--- a/src/SelfService/Domain/Models/Invitation.cs
+++ b/src/SelfService/Domain/Models/Invitation.cs
@@ -45,4 +45,10 @@ public class Invitation : Entity<InvitationId>
         Status = InvitationStatusOptions.Accepted;
         ModifiedAt = DateTime.UtcNow;
     }
+
+    public void Cancel()
+    {
+        Status = InvitationStatusOptions.Cancelled;
+        ModifiedAt = DateTime.UtcNow;
+    }
 }

--- a/src/SelfService/Domain/Models/InvitationStatusOptions.cs
+++ b/src/SelfService/Domain/Models/InvitationStatusOptions.cs
@@ -6,6 +6,7 @@ public class InvitationStatusOptions : ValueObjectEnum<InvitationStatusOptions>
     public static readonly InvitationStatusOptions Active = new("Active");
     public static readonly InvitationStatusOptions Declined = new("Declined");
     public static readonly InvitationStatusOptions Accepted = new("Accepted");
+    public static readonly InvitationStatusOptions Cancelled = new("Cancelled");
 
     private InvitationStatusOptions(string value)
         : base(value) { }

--- a/src/SelfService/Infrastructure/Persistence/InvitationRepository.cs
+++ b/src/SelfService/Infrastructure/Persistence/InvitationRepository.cs
@@ -6,4 +6,28 @@ public class InvitationRepository : GenericRepository<Invitation, InvitationId>,
 {
     public InvitationRepository(SelfServiceDbContext dbContext)
         : base(dbContext.Invitations) { }
+
+    public async Task<List<Invitation>> GetActiveInvitations(UserId userId, string targetId)
+    {
+        var invitations = await GetAllWithPredicate(
+            x => x.Invitee == userId && x.Status == InvitationStatusOptions.Active && x.TargetId == targetId
+        );
+        return invitations;
+    }
+
+    public async Task<List<Invitation>> GetOtherActiveInvitationsForSameTarget(
+        UserId userId,
+        string targetId,
+        InvitationId invitationId
+    )
+    {
+        var invitations = await GetAllWithPredicate(
+            x =>
+                x.Invitee == userId
+                && x.Status == InvitationStatusOptions.Active
+                && x.TargetId == targetId
+                && x.Id != invitationId
+        );
+        return invitations;
+    }
 }


### PR DESCRIPTION
closes dfds/cloudplatform/issues/2307

# Additional Review Notes
Prevents adding invitations for user-capability combinations which already have active invitations.
When accepting an invitaiton, all active invitations for same user-capability combination are cancelled.
When joining a capability by any means, all invitations for that same user and capability are cancelled.
