### PR TITLE
Moved validation of schema into service, added requirement for $schema to be equal to newest version

### DIFF
--- a/src/SelfService/Domain/Exceptions/InvalidJsonSchemaException.cs
+++ b/src/SelfService/Domain/Exceptions/InvalidJsonSchemaException.cs
@@ -19,6 +19,9 @@ public class InvalidJsonSchemaException : Exception
         return s.ToString();
     }
 
+    public InvalidJsonSchemaException(string customMessage)
+        : base(customMessage) { }
+
     public InvalidJsonSchemaException(EvaluationResults result)
         : base($"Invalid Json Schema, errors: {(result.HasErrors ? ErrorDictionaryToString(result.Errors) : "")}") { }
 }

--- a/src/SelfService/Domain/Services/ISelfServiceJsonSchemaService.cs
+++ b/src/SelfService/Domain/Services/ISelfServiceJsonSchemaService.cs
@@ -9,7 +9,7 @@ public interface ISelfServiceJsonSchemaService
 
     public Task<SelfServiceJsonSchema?> GetSchema(SelfServiceJsonSchemaObjectId objectId, int schemaVersion);
 
-    public void MustValidateJsonSchemaAgainstMetaSchema(string schema);
+    public void MustValidateJsonSchema(string schema);
 
     public Task<SelfServiceJsonSchema> AddSchema(SelfServiceJsonSchemaObjectId objectId, string schema);
 

--- a/src/SelfService/Infrastructure/Api/JsonSchema/SelfServiceJsonSchemaController.cs
+++ b/src/SelfService/Infrastructure/Api/JsonSchema/SelfServiceJsonSchemaController.cs
@@ -78,33 +78,11 @@ public class SelfServiceJsonSchemaController : ControllerBase
         if (request?.Schema == null)
             return BadRequest(new ProblemDetails { Title = "Invalid Schema", Detail = "Schema in request is null" });
 
-        if (!request.Schema.TryGetPropertyValue("$schema", out _))
-        {
-            return BadRequest(
-                new ProblemDetails()
-                {
-                    Title = "Invalid Schema",
-                    Detail = "Schema in request does not contain a $schema property"
-                }
-            );
-        }
-
-        if (!request.Schema.TryGetPropertyValue("$id", out _))
-        {
-            return BadRequest(
-                new ProblemDetails()
-                {
-                    Title = "Invalid Schema",
-                    Detail = "Schema in request does not contain a $id property"
-                }
-            );
-        }
-
         try
         {
-            _selfServiceJsonSchemaService.MustValidateJsonSchemaAgainstMetaSchema(request.Schema.ToJsonString());
+            _selfServiceJsonSchemaService.MustValidateJsonSchema(request.Schema.ToJsonString());
         }
-        catch (InvalidJsonSchemaException e) // sanity check
+        catch (InvalidJsonSchemaException e)
         {
             return BadRequest(
                 new ProblemDetails
@@ -113,6 +91,10 @@ public class SelfServiceJsonSchemaController : ControllerBase
                     Detail = $"Schema in request is not a valid json schema: {e.Message}"
                 }
             );
+        }
+        catch (Exception e)
+        {
+            return BadRequest(new ProblemDetails { Title = "Invalid Schema", Detail = $"Details: {e.Message}." });
         }
 
         try


### PR DESCRIPTION
closes dfds/cloudplatform/issues/2313

# Additional Review Notes
Added requirement because frontend expects this version and this version is already used for the meta-schema validation