### PR TITLE
added json metadata to capability list item

### DIFF
--- a/src/SelfService/Infrastructure/Api/ApiResourceFactory.cs
+++ b/src/SelfService/Infrastructure/Api/ApiResourceFactory.cs
@@ -203,6 +203,7 @@ public class ApiResourceFactory
             name: capability.Name,
             status: capability.Status.ToString(),
             description: capability.Description,
+            jsonMetadata: capability.JsonMetadata,
             links: new CapabilityListItemApiResource.CapabilityListItemLinks(
                 self: new ResourceLink(
                     href: _linkGenerator.GetUriByAction(

--- a/src/SelfService/Infrastructure/Api/Capabilities/CapabilityDetailsApiResource.cs
+++ b/src/SelfService/Infrastructure/Api/Capabilities/CapabilityDetailsApiResource.cs
@@ -88,6 +88,7 @@ public class CapabilityListItemApiResource
     public string Name { get; set; }
     public string Status { get; set; }
     public string Description { get; set; }
+    public string JsonMetadata { get; set; }
 
     [JsonPropertyName("_links")]
     public CapabilityListItemLinks Links { get; set; }
@@ -107,6 +108,7 @@ public class CapabilityListItemApiResource
         string name,
         string status,
         string description,
+        string jsonMetadata,
         CapabilityListItemLinks links
     )
     {
@@ -114,6 +116,7 @@ public class CapabilityListItemApiResource
         Name = name;
         Status = status;
         Description = description;
+        JsonMetadata = jsonMetadata;
         Links = links;
     }
 }


### PR DESCRIPTION
closes dfds/cloudplatform/issues/2333

# Additional Review Notes
From doing this task I found that capability resources already returns the json metadata directly, but the frontend uses the getMetadataEndpoint. I have made a task for it dfds/cloudplatform/issues/2357
