### PR TITLE
added new endpoint for changing metadata of required fields

### DIFF
--- a/src/SelfService.Tests/Application/TestCapabilityApplicationService.cs
+++ b/src/SelfService.Tests/Application/TestCapabilityApplicationService.cs
@@ -113,4 +113,27 @@ public class TestCapabilityApplicationService
             () => service.SetJsonMetadata(capability.Id, InvalidJsonMetadata)
         );
     }
+
+    [Fact]
+    public async Task fails_if_non_required_are_set()
+    {
+        await using var databaseFactory = new InMemoryDatabaseFactory();
+        var dbContext = await databaseFactory.CreateSelfServiceDbContext();
+        var (capability, _, service) = await SetupCapabilityMetadataTesting(
+            CreateSchema(1, SchemaWithRequiredField),
+            dbContext
+        );
+        Assert.False(await service.DoesOnlyModifyRequiredProperties(InvalidJsonMetadata, capability.Id));
+        Assert.True(await service.DoesOnlyModifyRequiredProperties(JsonMetadata, capability.Id));
+    }
+
+    [Fact]
+    public async Task fails_if_no_required_in_schema()
+    {
+        await using var databaseFactory = new InMemoryDatabaseFactory();
+        var dbContext = await databaseFactory.CreateSelfServiceDbContext();
+        var (capability, _, service) = await SetupCapabilityMetadataTesting(CreateSchema(0, SchemaEmpty), dbContext);
+        Assert.False(await service.DoesOnlyModifyRequiredProperties(InvalidJsonMetadata, capability.Id));
+        Assert.False(await service.DoesOnlyModifyRequiredProperties(JsonMetadata, capability.Id));
+    }
 }

--- a/src/SelfService/Application/ICapabilityApplicationService.cs
+++ b/src/SelfService/Application/ICapabilityApplicationService.cs
@@ -31,4 +31,5 @@ public interface ICapabilityApplicationService
     Task ActOnPendingCapabilityDeletions();
     Task SetJsonMetadata(CapabilityId capabilityId, string jsonMetadata);
     Task<string> GetJsonMetadata(CapabilityId capabilityId);
+    Task<bool> DoesOnlyModifyRequiredProperties(string jsonMetadata, CapabilityId capabilityId);
 }

--- a/src/SelfService/Infrastructure/Api/ApiResourceFactory.cs
+++ b/src/SelfService/Infrastructure/Api/ApiResourceFactory.cs
@@ -300,6 +300,30 @@ public class ApiResourceFactory
         );
     }
 
+    private async Task<ResourceLink> CreateSetRequiredMetadataLinkFor(Capability capability)
+    {
+        var allowedInteractions = Allow.None;
+
+        if (
+            await _membershipQuery.HasActiveMembership(CurrentUser, capability.Id)
+            || _authorizationService.CanGetSetCapabilityJsonMetadata(PortalUser)
+        )
+        {
+            allowedInteractions += Post;
+        }
+
+        return new ResourceLink(
+            href: _linkGenerator.GetUriByAction(
+                httpContext: HttpContext,
+                action: nameof(CapabilityController.SetCapabilityRequiredMetadata),
+                controller: GetNameOf<CapabilityController>(),
+                values: new { id = capability.Id }
+            ) ?? "",
+            rel: "self",
+            allow: allowedInteractions
+        );
+    }
+
     private async Task<ResourceLink> CreateSendInvitationsLinkFor(Capability capability)
     {
         var allowedInteractions = Allow.None;
@@ -343,6 +367,7 @@ public class ApiResourceFactory
         {
             allowedInteractions += Post;
         }
+
         return new ResourceLink(
             href: _linkGenerator.GetUriByAction(
                 httpContext: HttpContext,
@@ -471,6 +496,7 @@ public class ApiResourceFactory
                 requestCapabilityDeletion: await CreateRequestDeletionLinkFor(capability),
                 cancelCapabilityDeletionRequest: await CreateCancelDeletionRequestLinkFor(capability),
                 metadata: CreateMetadataLinkFor(capability),
+                setRequiredMetadata: await CreateSetRequiredMetadataLinkFor(capability),
                 getLinkedTeams: GetLinkedTeams(capability),
                 joinCapability: CreateJoinLinkFor(capability),
                 sendInvitations: await CreateSendInvitationsLinkFor(capability)

--- a/src/SelfService/Infrastructure/Api/Capabilities/CapabilityController.cs
+++ b/src/SelfService/Infrastructure/Api/Capabilities/CapabilityController.cs
@@ -775,6 +775,93 @@ public class CapabilityController : ControllerBase
         return Ok(metadata);
     }
 
+    [HttpPost("{id}/required-metadata")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest, "application/problem+json")]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized, "application/problem+json")]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound, "application/problem+json")]
+    public async Task<IActionResult> SetCapabilityRequiredMetadata(
+        string id,
+        [FromBody] SetCapabilityMetadataRequest request
+    )
+    {
+        // Verify user and fetch userId
+        if (!User.TryGetUserId(out var userId))
+            return Unauthorized(
+                new ProblemDetails
+                {
+                    Title = "Unknown user id",
+                    Detail = "User id is not valid and thus set capability metadata."
+                }
+            );
+
+        if (!CapabilityId.TryParse(id, out var capabilityId))
+            return NotFound(
+                new ProblemDetails
+                {
+                    Title = "Capability not found.",
+                    Detail = $"A capability with id \"{id}\" could not be found."
+                }
+            );
+
+        var portalUser = HttpContext.User.ToPortalUser();
+        if (!_authorizationService.CanGetSetCapabilityJsonMetadata(portalUser))
+            return Unauthorized(
+                new ProblemDetails
+                {
+                    Title = "Not authorized",
+                    Detail = $"User \"{userId}\" is not authorized to set capability metadata."
+                }
+            );
+
+        if (request?.JsonMetadata == null)
+            return BadRequest(
+                new ProblemDetails
+                {
+                    Title = "Invalid metadata",
+                    Detail = "Request body is empty",
+                    Status = StatusCodes.Status400BadRequest
+                }
+            );
+
+        var jsonString = request.JsonMetadata.ToJsonString();
+        if (!await _capabilityApplicationService.DoesOnlyModifyRequiredProperties(jsonString, capabilityId))
+        {
+            return BadRequest(
+                new ProblemDetails
+                {
+                    Title = "Invalid metadata",
+                    Detail = "Json metadata in request changed properties that are not required",
+                    Status = StatusCodes.Status400BadRequest
+                }
+            );
+        }
+
+        try
+        {
+            await _capabilityApplicationService.SetJsonMetadata(capabilityId, jsonString);
+        }
+        catch (InvalidJsonMetadataException e)
+        {
+            return BadRequest(
+                new ProblemDetails
+                {
+                    Title = "Invalid json metadata",
+                    Detail = e.Message,
+                    Status = StatusCodes.Status400BadRequest
+                }
+            );
+        }
+        catch (Exception e)
+        {
+            return CustomObjectResult.InternalServerError(
+                new ProblemDetails { Title = "Uncaught Exception", Detail = $"SetCapabilityMetadata: {e.Message}." }
+            );
+        }
+
+        return Ok();
+    }
+
     [HttpPost("{id}/metadata")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest, "application/problem+json")]

--- a/src/SelfService/Infrastructure/Api/Capabilities/CapabilityDetailsApiResource.cs
+++ b/src/SelfService/Infrastructure/Api/Capabilities/CapabilityDetailsApiResource.cs
@@ -28,6 +28,7 @@ public class CapabilityDetailsApiResource
         public ResourceLink CancelCapabilityDeletionRequest { get; set; }
 
         public ResourceLink Metadata { get; set; }
+        public ResourceLink SetRequiredMetadata { get; set; }
         public ResourceLink GetLinkedTeams { get; set; }
         public ResourceLink JoinCapability { get; set; }
         public ResourceLink SendInvitations { get; set; }
@@ -42,6 +43,7 @@ public class CapabilityDetailsApiResource
             ResourceLink requestCapabilityDeletion,
             ResourceLink cancelCapabilityDeletionRequest,
             ResourceLink metadata,
+            ResourceLink setRequiredMetadata,
             ResourceLink getLinkedTeams,
             ResourceLink joinCapability,
             ResourceLink sendInvitations
@@ -56,6 +58,7 @@ public class CapabilityDetailsApiResource
             RequestCapabilityDeletion = requestCapabilityDeletion;
             CancelCapabilityDeletionRequest = cancelCapabilityDeletionRequest;
             Metadata = metadata;
+            SetRequiredMetadata = setRequiredMetadata;
             GetLinkedTeams = getLinkedTeams;
             JoinCapability = joinCapability;
             SendInvitations = sendInvitations;


### PR DESCRIPTION
closes dfds/cloudplatform/issues/2401

# Additional Review Notes
Added new endpoint that I presume will be temporary and removed when we give full control to users of setting json metadata.

The endpoint checks if the metadata in the request only changes properties which are required