### PR TITLE
Feature/2420 make selfservice api handle failed topic schema registration

### DIFF
--- a/db/seed/MessageContract.csv
+++ b/db/seed/MessageContract.csv
@@ -1,3 +1,4 @@
 Id;KafkaTopicId;MessageType;Description;Example;Schema;Status;CreatedAt;CreatedBy;ModifiedAt;ModifiedBy
 AC4E4454-A30A-4731-989F-CA478D8AD979;269C3064-E1AD-49A8-8FE8-781E04A51303;something-created;Something has been created - cool!;{"foo": "bar"};{"fooschema": "barschema"};Provisioned;2023-02-10T08:00:00;SeedScript;2023-02-10T08:00:00;SeedScript
 16A8159E-F61F-431D-9A22-D3BF03F4FBD2;269C3064-E1AD-49A8-8FE8-781E04A51303;something-updated;Someone updated something - yay!;{"foo2": "bar2"};{"foo2schema": "bar2schema"};In Progress;2023-02-10T08:00:00;SeedScript;2023-02-10T08:00:00;SeedScript
+c867bc57-3c2b-4d8f-927b-0ffe445471f4;269C3064-E1AD-49A8-8FE8-781E04A51303;something-deleted;Someone has tried to provision this contract but it failed;{foo3: bar3};{foo3schema: bar3schema};Failed;2023-02-10 08:00:00.000000;SeedScript;2023-12-28 09:45:24.263458;krijens@dfds.com

--- a/db/seed/MessageContract.csv
+++ b/db/seed/MessageContract.csv
@@ -1,4 +1,4 @@
 Id;KafkaTopicId;MessageType;Description;Example;Schema;Status;CreatedAt;CreatedBy;ModifiedAt;ModifiedBy
 AC4E4454-A30A-4731-989F-CA478D8AD979;269C3064-E1AD-49A8-8FE8-781E04A51303;something-created;Something has been created - cool!;{"foo": "bar"};{"fooschema": "barschema"};Provisioned;2023-02-10T08:00:00;SeedScript;2023-02-10T08:00:00;SeedScript
 16A8159E-F61F-431D-9A22-D3BF03F4FBD2;269C3064-E1AD-49A8-8FE8-781E04A51303;something-updated;Someone updated something - yay!;{"foo2": "bar2"};{"foo2schema": "bar2schema"};In Progress;2023-02-10T08:00:00;SeedScript;2023-02-10T08:00:00;SeedScript
-c867bc57-3c2b-4d8f-927b-0ffe445471f4;269C3064-E1AD-49A8-8FE8-781E04A51303;something-deleted;Someone has tried to provision this contract but it failed;{foo3: bar3};{foo3schema: bar3schema};Failed;2023-02-10 08:00:00.000000;SeedScript;2023-12-28 09:45:24.263458;krijens@dfds.com
+c867bc57-3c2b-4d8f-927b-0ffe445471f4;269C3064-E1AD-49A8-8FE8-781E04A51303;something-failed;Someone has tried to provision this contract but it failed;{foo3: bar3};{foo3schema: bar3schema};Failed;2023-02-10 08:00:00.000000;SeedScript;2023-12-28 09:45:24.263458;krijens@dfds.com

--- a/src/SelfService/Application/IKafkaTopicApplicationService.cs
+++ b/src/SelfService/Application/IKafkaTopicApplicationService.cs
@@ -13,7 +13,14 @@ public interface IKafkaTopicApplicationService
         string requestedBy
     );
 
+    Task RetryRequestNewMessageContract(
+        KafkaTopicId kafkaTopicId,
+        MessageContractId messageContractId,
+        string requestedBy
+    );
+
     Task RegisterMessageContractAsProvisioned(MessageContractId messageContractId, string changedBy);
+    Task RegisterMessageContractAsFailed(MessageContractId messageContractId, string changedBy);
 
     Task RegisterKafkaTopicAsInProgress(KafkaTopicId kafkaTopicId, string changedBy);
     Task RegisterKafkaTopicAsProvisioned(KafkaTopicId kafkaTopicId, string changedBy);

--- a/src/SelfService/Domain/Events/SchemaRegistrationFailed.cs
+++ b/src/SelfService/Domain/Events/SchemaRegistrationFailed.cs
@@ -1,0 +1,9 @@
+using SelfService.Domain.Models;
+
+namespace SelfService.Domain.Events;
+
+public class SchemaRegistrationFailed : IDomainEvent
+{
+    public string? MessageContractId { get; set; }
+    public string? Reason { get; set; }
+}

--- a/src/SelfService/Domain/Models/IMessageContractRepository.cs
+++ b/src/SelfService/Domain/Models/IMessageContractRepository.cs
@@ -3,6 +3,7 @@
 public interface IMessageContractRepository
 {
     Task Add(MessageContract messageContract);
+    void Update(MessageContract messageContract);
     Task<MessageContract> Get(MessageContractId id);
     Task<MessageContract?> FindBy(MessageContractId id);
     Task<IEnumerable<MessageContract>> FindBy(KafkaTopicId topicId);

--- a/src/SelfService/Domain/Models/MessageContractStatus.cs
+++ b/src/SelfService/Domain/Models/MessageContractStatus.cs
@@ -5,6 +5,7 @@ public class MessageContractStatus : ValueObject
     public static readonly MessageContractStatus Requested = new("Requested");
     public static readonly MessageContractStatus InProgress = new("In Progress");
     public static readonly MessageContractStatus Provisioned = new("Provisioned");
+    public static readonly MessageContractStatus Failed = new("Failed");
 
     private readonly string _value;
 
@@ -50,7 +51,8 @@ public class MessageContractStatus : ValueObject
         return false;
     }
 
-    public static IReadOnlyCollection<MessageContractStatus> Values => new[] { Requested, InProgress, Provisioned };
+    public static IReadOnlyCollection<MessageContractStatus> Values =>
+        new[] { Requested, InProgress, Provisioned, Failed };
 
     public static implicit operator MessageContractStatus(string text) => Parse(text);
 

--- a/src/SelfService/Domain/Policies/MarkMessageContractAsFailed.cs
+++ b/src/SelfService/Domain/Policies/MarkMessageContractAsFailed.cs
@@ -1,0 +1,72 @@
+using Dafda.Consuming;
+using SelfService.Application;
+using SelfService.Domain.Events;
+using SelfService.Domain.Exceptions;
+using SelfService.Domain.Models;
+
+namespace SelfService.Domain.Policies;
+
+public class MarkMessageContractAsFailed : IMessageHandler<SchemaRegistrationFailed>
+{
+    private readonly ILogger<MarkMessageContractAsFailed> _logger;
+    private readonly IKafkaTopicApplicationService _kafkaTopicApplicationService;
+    private readonly IMessageContractRepository _messageContractRepository;
+
+    public MarkMessageContractAsFailed(
+        ILogger<MarkMessageContractAsFailed> logger,
+        IKafkaTopicApplicationService kafkaTopicApplicationService,
+        IMessageContractRepository messageContractRepository
+    )
+    {
+        _logger = logger;
+        _kafkaTopicApplicationService = kafkaTopicApplicationService;
+        _messageContractRepository = messageContractRepository;
+    }
+
+    public async Task Handle(SchemaRegistrationFailed message, MessageHandlerContext context)
+    {
+        using var _ = _logger.BeginScope(
+            "Handling {MessageType} on {ImplementationType} with {CorrelationId} and {CausationId}",
+            context.MessageType,
+            GetType().Name,
+            context.CorrelationId,
+            context.CausationId
+        );
+        if (!MessageContractId.TryParse(message.MessageContractId, out var messageContractId))
+        {
+            _logger.LogError(
+                "Cannot mark message contract as failed because message contract id \"{MessageContractId}\" is not valid - skipping message {MessageId}",
+                message.MessageContractId,
+                context.MessageId
+            );
+
+            return;
+        }
+
+        var storedContract = await _messageContractRepository.Get(messageContractId);
+
+        _logger.LogError(
+            "failed to register message contract {MessageContractId} for topic {TopicId} with reason: {MessageContractFailedReason}",
+            message.MessageContractId,
+            storedContract.KafkaTopicId,
+            message.Reason
+        );
+
+        try
+        {
+            var changedBy = string.Join("/", "SYSTEM", GetType().FullName);
+            await _kafkaTopicApplicationService.RegisterMessageContractAsFailed(
+                messageContractId: messageContractId,
+                changedBy: changedBy
+            );
+        }
+        catch (EntityNotFoundException<MessageContract> err)
+        {
+            _logger.LogError(
+                err,
+                "Message contract \"{MessageContractId}\" could not be found and cannot be marked as failed - skipping!",
+                messageContractId
+            );
+        }
+    }
+}

--- a/src/SelfService/Domain/Services/AuthorizationService.cs
+++ b/src/SelfService/Domain/Services/AuthorizationService.cs
@@ -1,5 +1,6 @@
 ﻿using SelfService.Domain.Models;
 using SelfService.Domain.Queries;
+using SelfService.Infrastructure.Persistence;
 
 namespace SelfService.Domain.Services;
 
@@ -9,18 +10,24 @@ public class AuthorizationService : IAuthorizationService
     private readonly IMembershipQuery _membershipQuery;
     private readonly IKafkaClusterAccessRepository _kafkaClusterAccessRepository;
     private readonly IAwsAccountRepository _awsAccountRepository;
+    private readonly IMessageContractRepository _messageContractRepository;
+    private readonly IKafkaTopicRepository _kafkaTopicRepository;
 
     public AuthorizationService(
         ILogger<AuthorizationService> logger,
         IMembershipQuery membershipQuery,
         IKafkaClusterAccessRepository kafkaClusterAccessRepository,
-        IAwsAccountRepository awsAccountRepository
+        IAwsAccountRepository awsAccountRepository,
+        IMessageContractRepository messageContractRepository,
+        IKafkaTopicRepository kafkaTopicRepository
     )
     {
         _logger = logger;
         _membershipQuery = membershipQuery;
         _kafkaClusterAccessRepository = kafkaClusterAccessRepository;
         _awsAccountRepository = awsAccountRepository;
+        _messageContractRepository = messageContractRepository;
+        _kafkaTopicRepository = kafkaTopicRepository;
     }
 
     public async Task<bool> CanAdd(UserId userId, CapabilityId capabilityId, KafkaClusterId clusterId)
@@ -210,5 +217,18 @@ public class AuthorizationService : IAuthorizationService
         bool isMember = await _membershipQuery.HasActiveMembership(portalUser.Id, capabilityId);
         bool isCloudEngineer = portalUser.Roles.Any(role => role == UserRole.CloudEngineer);
         return isMember || isCloudEngineer;
+    }
+
+    public async Task<bool> CanRetryCreatingMessageContract(PortalUser portalUser, MessageContractId messageContractId)
+    {
+        var messageContract = await _messageContractRepository.Get(messageContractId);
+        if (messageContract.Status != MessageContractStatus.Failed)
+        {
+            return false;
+        }
+        var kafkaTopic = await _kafkaTopicRepository.Get(messageContract.KafkaTopicId);
+        bool isMember = await _membershipQuery.HasActiveMembership(portalUser.Id, kafkaTopic.CapabilityId);
+        bool isCloudEngineer = portalUser.Roles.Any(role => role == UserRole.CloudEngineer);
+        return (kafkaTopic.IsPrivate && isMember) || isCloudEngineer || !kafkaTopic.IsPrivate;
     }
 }

--- a/src/SelfService/Domain/Services/IAuthorizationService.cs
+++ b/src/SelfService/Domain/Services/IAuthorizationService.cs
@@ -29,4 +29,5 @@ public interface IAuthorizationService
     bool CanBypassMembershipApprovals(PortalUser portalUser);
     Task<bool> CanInviteToCapability(UserId userId, CapabilityId capabilityId);
     Task<bool> CanSeeAwsAccountId(PortalUser portalUser, CapabilityId capabilityId);
+    Task<bool> CanRetryCreatingMessageContract(PortalUser portalUser, MessageContractId messageContractId);
 }

--- a/src/SelfService/Infrastructure/Api/Capabilities/MessageContractApiResource.cs
+++ b/src/SelfService/Infrastructure/Api/Capabilities/MessageContractApiResource.cs
@@ -18,10 +18,12 @@ public class MessageContractApiResource
     public class MessageContractLinks
     {
         public ResourceLink Self { get; set; }
+        public ResourceLink Retry { get; set; }
 
-        public MessageContractLinks(ResourceLink self)
+        public MessageContractLinks(ResourceLink self, ResourceLink retry)
         {
             Self = self;
+            Retry = retry;
         }
     }
 

--- a/src/SelfService/Infrastructure/Api/Kafka/KafkaTopicController.cs
+++ b/src/SelfService/Infrastructure/Api/Kafka/KafkaTopicController.cs
@@ -471,27 +471,13 @@ public class KafkaTopicController : ControllerBase
             return BadRequest(ModelState);
         }
 
-        var topic = await _kafkaTopicRepository.FindBy(kafkaTopicId);
-        if (topic is null)
-        {
-            return NotFound(
-                new ProblemDetails
-                {
-                    Title = "Kafka topic not found",
-                    Detail = $"Kafka topic with id \"{id}\" is not known by the system."
-                }
-            );
-        }
-
-        var hasAccess = await _membershipQuery.HasActiveMembership(userId, topic.CapabilityId);
-        if (topic.IsPrivate && !hasAccess)
+        if (!await _authorizationService.CanRetryCreatingMessageContract(User.ToPortalUser(), messageContractId))
         {
             return Unauthorized(
                 new ProblemDetails
                 {
                     Title = "Access denied!",
-                    Detail =
-                        $"Topic \"{topic.Name}\" belongs to a capability that user \"{userId}\" does not have access to."
+                    Detail = $"User does not have permission to retry creating message contract",
                 }
             );
         }

--- a/src/SelfService/Infrastructure/Api/Kafka/KafkaTopicController.cs
+++ b/src/SelfService/Infrastructure/Api/Kafka/KafkaTopicController.cs
@@ -1,6 +1,4 @@
 using Microsoft.AspNetCore.Mvc;
-using System.Net.Http;
-using Microsoft.AspNetCore.Http;
 using SelfService.Application;
 using SelfService.Domain.Exceptions;
 using SelfService.Domain.Models;
@@ -381,43 +379,19 @@ public class KafkaTopicController : ControllerBase
             );
         }
 
-        if (!KafkaTopicId.TryParse(id, out var kafkaTopicId))
-        {
-            return NotFound(
-                new ProblemDetails
-                {
-                    Title = "Kafka topic not found",
-                    Detail = $"Kafka topic with id \"{id}\" is not known by the system."
-                }
+        var (kafkaTopicId, messageType, contractExample, contractSchema) = RequestParserRegistry
+            .StringToValueParser(ModelState)
+            .Parse<KafkaTopicId, MessageType, MessageContractExample, MessageContractSchema>(
+                id,
+                payload.MessageType,
+                payload.Example,
+                payload.Schema
             );
-        }
-
-        if (!MessageType.TryParse(payload.MessageType, out var messageType))
-        {
-            ModelState.AddModelError(
-                nameof(payload.MessageType),
-                $"Value \"{payload.MessageType}\" is not a valid message type."
-            );
-        }
-
-        if (string.IsNullOrWhiteSpace(payload.Description))
-        {
-            ModelState.AddModelError(nameof(payload.Description), "Value for description cannot be empty.");
-        }
-
-        if (!MessageContractExample.TryParse(payload.Example, out var contractExample))
-        {
-            ModelState.AddModelError(nameof(payload.Example), $"Value \"{payload.Example}\" is not a valid example.");
-        }
-
-        if (!MessageContractSchema.TryParse(payload.Schema, out var contractSchema))
-        {
-            ModelState.AddModelError(nameof(payload.Schema), $"Value \"{payload.Schema}\" is not a valid schema.");
-        }
+        RequestParserRegistry.AddErrorIfNull(payload.Description, "description", ModelState);
 
         if (!ModelState.IsValid)
         {
-            return ValidationProblem();
+            return BadRequest(ModelState);
         }
 
         var topic = await _kafkaTopicRepository.FindBy(kafkaTopicId);
@@ -466,6 +440,76 @@ public class KafkaTopicController : ControllerBase
                 {
                     Title = "Message type already exists",
                     Detail = $"Topic \"{topic.Name}\" already has a message with message type \"{messageType}\"."
+                }
+            );
+        }
+    }
+
+    [HttpPost("{id:required}/messagecontracts/{contractId:required}/retry")]
+    [ProducesResponseType(typeof(KafkaTopicApiResource), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized, "application/problem+json")]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound, "application/problem+json")]
+    public async Task<IActionResult> RetryCreatingMessageContract([FromRoute] string id, [FromRoute] string contractId)
+    {
+        if (!User.TryGetUserId(userId: out var userId))
+        {
+            return Unauthorized(
+                new ProblemDetails
+                {
+                    Title = "Access denied!",
+                    Detail = $"User could not be granted access to adding message contracts.",
+                }
+            );
+        }
+
+        var (kafkaTopicId, messageContractId) = RequestParserRegistry
+            .StringToValueParser(ModelState)
+            .Parse<KafkaTopicId, MessageContractId>(id, contractId);
+
+        if (!ModelState.IsValid)
+        {
+            return BadRequest(ModelState);
+        }
+
+        var topic = await _kafkaTopicRepository.FindBy(kafkaTopicId);
+        if (topic is null)
+        {
+            return NotFound(
+                new ProblemDetails
+                {
+                    Title = "Kafka topic not found",
+                    Detail = $"Kafka topic with id \"{id}\" is not known by the system."
+                }
+            );
+        }
+
+        var hasAccess = await _membershipQuery.HasActiveMembership(userId, topic.CapabilityId);
+        if (topic.IsPrivate && !hasAccess)
+        {
+            return Unauthorized(
+                new ProblemDetails
+                {
+                    Title = "Access denied!",
+                    Detail =
+                        $"Topic \"{topic.Name}\" belongs to a capability that user \"{userId}\" does not have access to."
+                }
+            );
+        }
+
+        try
+        {
+            await _kafkaTopicApplicationService.RetryRequestNewMessageContract(kafkaTopicId, messageContractId, userId);
+
+            var messageContract = await _messageContractRepository.Get(messageContractId);
+            return Ok(_apiResourceFactory.Convert(messageContract));
+        }
+        catch (Exception e)
+        {
+            return CustomObjectResult.InternalServerError(
+                new ProblemDetails
+                {
+                    Title = "Uncaught Exception",
+                    Detail = $"Failed to retry creating message contract: {e.InnerException}."
                 }
             );
         }

--- a/src/SelfService/Infrastructure/Api/RequestParser.cs
+++ b/src/SelfService/Infrastructure/Api/RequestParser.cs
@@ -133,4 +133,12 @@ public static class RequestParserRegistry
         StringToValueObject.SetModelStateParser(modelStateDictionary);
         return StringToValueObject;
     }
+
+    public static void AddErrorIfNull(string? value, string valueName, ModelStateDictionary modelStateDictionary)
+    {
+        if (value != null)
+            return;
+
+        modelStateDictionary.AddModelError(valueName, $"Value {valueName} can not be null");
+    }
 }

--- a/src/SelfService/Infrastructure/Messaging/ConsumerConfiguration.cs
+++ b/src/SelfService/Infrastructure/Messaging/ConsumerConfiguration.cs
@@ -129,7 +129,9 @@ public static class ConsumerConfiguration
                 .ForTopic($"{ConfluentGatewayPrefix}.schema")
                 .RegisterMessageHandler<SchemaRegistered, MarkMessageContractAsProvisioned>("schema-registered")
                 .RegisterMessageHandler<SchemaRegistered, MarkMessageContractAsProvisioned>("schema_registered") // NOTE [jandr@2023-03-29]: double registration due to underscore/dash confusion - we should be using dashes
-                .Ignore("schema-registration-failed");
+                .RegisterMessageHandler<SchemaRegistrationFailed, MarkMessageContractAsFailed>(
+                    "schema-registration-failed"
+                );
             options
                 .ForTopic($"{ConfluentGatewayPrefix}.provisioning")
                 .RegisterMessageHandler<KafkaTopicProvisioningHasBegun, UpdateKafkaTopicProvisioningProgress>(

--- a/src/SelfService/Infrastructure/Persistence/MessageContractRepository.cs
+++ b/src/SelfService/Infrastructure/Persistence/MessageContractRepository.cs
@@ -18,6 +18,11 @@ public class MessageContractRepository : IMessageContractRepository
         await _dbContext.MessageContracts.AddAsync(messageContract);
     }
 
+    public void Update(MessageContract messageContract)
+    {
+        _dbContext.MessageContracts.Update(messageContract);
+    }
+
     public async Task<MessageContract> Get(MessageContractId id)
     {
         var result = await _dbContext.MessageContracts.FindAsync(id);


### PR DESCRIPTION
closes dfds/cloudplatform/issues/2420

# Additional Review Notes
- Added endpoint for retrying adding message contract
- Now handles the kafka message for failing schema registration with new failed status