### PR TITLE
Verify id existence and not just correctness

### DIFF
--- a/src/SelfService/Infrastructure/Api/Capabilities/CapabilityController.cs
+++ b/src/SelfService/Infrastructure/Api/Capabilities/CapabilityController.cs
@@ -516,6 +516,16 @@ public class CapabilityController : ControllerBase
                 }
             );
 
+        var capability = await _capabilityRepository.FindBy(capabilityId);
+        if (capability == null)
+            return NotFound(
+                new ProblemDetails
+                {
+                    Title = "Capability not found.",
+                    Detail = $"A capability with id \"{id}\" could not be found."
+                }
+            );
+
         var clusters = await _kafkaClusterRepository.GetAll();
 
         return Ok(await _apiResourceFactory.Convert(capabilityId, clusters));


### PR DESCRIPTION
closes dfds/cloudplatform/issues/2323

# Additional Review Notes
This is the simplest solution to the 'issue'.
This issue was reported, since it was confusing that the API returned responses for non-existent (but valid) capability ids -- something which will no longer be the case.
This issue is only observable when playing around with the API directly, which is something very few -- if any -- do.

I cannot figure out is this endpoint is a direct result of intense DDD or the exact opposite.
In any case, I don't think it is worth spending the time to take it apart for restructuring either 🤷 
