### PR TITLE
Fix ecr response type

### DIFF
--- a/src/SelfService/Infrastructure/Api/Capabilities/CapabilityController.cs
+++ b/src/SelfService/Infrastructure/Api/Capabilities/CapabilityController.cs
@@ -76,7 +76,7 @@ public class CapabilityController : ControllerBase
     }
 
     [HttpPost("")]
-    [ProducesResponseType(typeof(CapabilityDetailsApiResource), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(CapabilityDetailsApiResource), StatusCodes.Status201Created)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest, "application/problem+json")]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized, "application/problem+json")]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict, "application/problem+json")]

--- a/src/SelfService/Infrastructure/Api/ECRRepositories/ECRRepositoriesController.cs
+++ b/src/SelfService/Infrastructure/Api/ECRRepositories/ECRRepositoriesController.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Mvc;
+using SelfService.Domain.Models;
 using SelfService.Domain.Services;
 using SelfService.Infrastructure.Api.Capabilities;
 
@@ -22,7 +23,7 @@ public class ECRRepositoriesController : ControllerBase
     }
 
     [HttpGet("repositories")]
-    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(IEnumerable<ECRRepository>), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized, "application/problem+json")]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound, "application/problem+json")]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status500InternalServerError, "application/problem+json")]

--- a/src/SelfService/Infrastructure/Api/ECRRepositories/ECRRepositoriesController.cs
+++ b/src/SelfService/Infrastructure/Api/ECRRepositories/ECRRepositoriesController.cs
@@ -48,7 +48,7 @@ public class ECRRepositoriesController : ControllerBase
     }
 
     [HttpPost("repositories")]
-    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ECRRepository), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized, "application/problem+json")]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound, "application/problem+json")]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status500InternalServerError, "application/problem+json")]


### PR DESCRIPTION
closes dfds/cloudplatform/issues/`pr-issue-number` 

# Additional Review Notes
Had to fix some response types of the api in order to make the autogenerated api client for the CLI to work
