### PR TITLE
lock version of pgup

### DIFF
--- a/db/Dockerfile
+++ b/db/Dockerfile
@@ -1,4 +1,4 @@
-FROM dfdsdk/pgup:latest
+FROM dfdsdk/pgup:v0.0.1
 
 RUN apk update && apk add curl && apk add ca-certificates && rm -rf /var/cache/apk/*
 


### PR DESCRIPTION
# Additional Review Notes
We should not depend on 'latest', as this _may_ cause issues if updates to pgup happens that could break things for us
