### PR TITLE
Take control of Aspectly functionality

### DIFF
--- a/src/SelfService.Tests/SelfService.Tests.csproj
+++ b/src/SelfService.Tests/SelfService.Tests.csproj
@@ -11,8 +11,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.3" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="7.0.3" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="7.0.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="7.0.18" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="7.0.18" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
     <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="xunit" Version="2.4.2" />

--- a/src/SelfService/Domain/Aspectly/AspectContext.cs
+++ b/src/SelfService/Domain/Aspectly/AspectContext.cs
@@ -1,0 +1,15 @@
+using System.Reflection;
+
+namespace SelfService.Domain.Aspectly;
+
+public class AspectContext
+{
+    public AspectContext(MethodInfo method, Attribute triggerAttribute)
+    {
+        Method = method;
+        TriggerAttribute = triggerAttribute;
+    }
+
+    public Attribute TriggerAttribute { get; }
+    public MethodInfo Method { get; }
+}

--- a/src/SelfService/Domain/Aspectly/AspectOptionsBuilder.cs
+++ b/src/SelfService/Domain/Aspectly/AspectOptionsBuilder.cs
@@ -1,0 +1,15 @@
+namespace SelfService.Domain.Aspectly;
+
+internal class AspectOptionsBuilder : IAspectOptions
+{
+    private readonly LinkedList<AttributeAspectMap> _maps = new LinkedList<AttributeAspectMap>();
+
+    public void Register<TAttribute, TAspect>()
+        where TAttribute : Attribute
+        where TAspect : class, IAspect
+    {
+        _maps.AddLast(new AttributeAspectMap(typeof(TAttribute), typeof(TAspect)));
+    }
+
+    public IEnumerable<AttributeAspectMap> Maps => _maps;
+}

--- a/src/SelfService/Domain/Aspectly/AspectRegistry.cs
+++ b/src/SelfService/Domain/Aspectly/AspectRegistry.cs
@@ -1,0 +1,138 @@
+using System.Reflection;
+
+namespace SelfService.Domain.Aspectly;
+
+internal class AspectRegistry
+{
+    private readonly List<AspectTriggerMap> _aspectTriggers = new List<AspectTriggerMap>();
+    private readonly Dictionary<MethodInfo, AnnotatedServiceRegistration> _registrations =
+        new Dictionary<MethodInfo, AnnotatedServiceRegistration>();
+
+    public IEnumerable<Type> RegisteredAspectTypes => _aspectTriggers.Select(x => x.AspectType);
+    public IEnumerable<Type> RegisteredTriggerAttributeTypes => _aspectTriggers.Select(x => x.TriggerAttributeType);
+
+    public void RegisterAspectTrigger(Type triggerAttributeType, Type aspectType)
+    {
+        if (!typeof(Attribute).IsAssignableFrom(triggerAttributeType))
+        {
+            throw new InvalidTriggerTypeException(
+                $"Type {triggerAttributeType} is an invalid trigger type. It must inherit from {typeof(Attribute)}."
+            );
+        }
+
+        if (!typeof(IAspect).IsAssignableFrom(aspectType))
+        {
+            throw new InvalidAspectTypeException(
+                $"Type {aspectType} is an invalid aspect type. It must implement {typeof(IAspect)}."
+            );
+        }
+
+        _aspectTriggers.Add(new AspectTriggerMap(triggerAttributeType, aspectType));
+    }
+
+    public bool HasTriggers(Type implementationType)
+    {
+        foreach (var methodInfo in implementationType.GetMethods())
+        {
+            foreach (var attribute in methodInfo.GetCustomAttributes())
+            {
+                if (RegisteredTriggerAttributeTypes.Contains(attribute.GetType()))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    public void RegisterAnnotatedService(Type implementationType)
+    {
+        foreach (var methodInfo in implementationType.GetMethods())
+        {
+            var registration = new AnnotatedServiceRegistration(methodInfo);
+
+            foreach (var attribute in methodInfo.GetCustomAttributes())
+            {
+                var triggerMap = _aspectTriggers.SingleOrDefault(x => x.TriggerAttributeType == attribute.GetType());
+
+                if (triggerMap is not null)
+                {
+                    var temp = new TriggerInstanceToAspectType(attribute, triggerMap.AspectType);
+                    registration.AddTrigger(temp);
+                }
+            }
+
+            if (registration.HasTriggers)
+            {
+                _registrations.Add(registration.Method, registration);
+            }
+        }
+    }
+
+    public AnnotatedServiceRegistration? GetAspectRegistrationFor(MethodInfo method)
+    {
+        _registrations.TryGetValue(method, out var registration);
+        return registration;
+    }
+
+    #region private helpers
+
+    #endregion
+}
+
+internal class TriggerInstanceToAspectType
+{
+    public TriggerInstanceToAspectType(Attribute attribute, Type aspectType)
+    {
+        Attribute = attribute;
+        AspectType = aspectType;
+    }
+
+    public Attribute Attribute { get; private set; }
+    public Type AspectType { get; private set; }
+}
+
+internal class AspectTriggerMap
+{
+    public AspectTriggerMap(Type triggerAttributeType, Type aspectType)
+    {
+        TriggerAttributeType = triggerAttributeType;
+        AspectType = aspectType;
+    }
+
+    public Type TriggerAttributeType { get; }
+    public Type AspectType { get; }
+}
+
+internal class AnnotatedServiceRegistration
+{
+    private readonly LinkedList<TriggerInstanceToAspectType> _toAspectTypes = new();
+
+    public AnnotatedServiceRegistration(MethodInfo method)
+    {
+        Method = method;
+    }
+
+    public MethodInfo Method { get; }
+    public IEnumerable<TriggerInstanceToAspectType> Duno => _toAspectTypes;
+
+    public bool HasTriggers => _toAspectTypes.Any();
+
+    public void AddTrigger(TriggerInstanceToAspectType toAspectType)
+    {
+        _toAspectTypes.AddLast(toAspectType);
+    }
+}
+
+public class InvalidTriggerTypeException : Exception
+{
+    public InvalidTriggerTypeException(string message)
+        : base(message) { }
+}
+
+public class InvalidAspectTypeException : Exception
+{
+    public InvalidAspectTypeException(string message)
+        : base(message) { }
+}

--- a/src/SelfService/Domain/Aspectly/AttributeAspectMap.cs
+++ b/src/SelfService/Domain/Aspectly/AttributeAspectMap.cs
@@ -1,0 +1,13 @@
+namespace SelfService.Domain.Aspectly;
+
+internal class AttributeAspectMap
+{
+    public AttributeAspectMap(Type attribute, Type aspect)
+    {
+        Attribute = attribute;
+        Aspect = aspect;
+    }
+
+    public Type Attribute { get; private set; }
+    public Type Aspect { get; private set; }
+}

--- a/src/SelfService/Domain/Aspectly/IAspect.cs
+++ b/src/SelfService/Domain/Aspectly/IAspect.cs
@@ -1,0 +1,8 @@
+namespace SelfService.Domain.Aspectly;
+
+public interface IAspect
+{
+    Task Invoke(AspectContext context, AspectDelegate next);
+}
+
+public delegate Task AspectDelegate();

--- a/src/SelfService/Domain/Aspectly/IAspectOptions.cs
+++ b/src/SelfService/Domain/Aspectly/IAspectOptions.cs
@@ -1,0 +1,10 @@
+using SelfService.Domain.Aspectly;
+
+namespace Microsoft.Extensions.DependencyInjection;
+
+public interface IAspectOptions
+{
+    void Register<TAttribute, TAspect>()
+        where TAttribute : Attribute
+        where TAspect : class, IAspect;
+}

--- a/src/SelfService/Domain/Aspectly/InterceptPipeline.cs
+++ b/src/SelfService/Domain/Aspectly/InterceptPipeline.cs
@@ -1,0 +1,34 @@
+namespace SelfService.Domain.Aspectly;
+
+internal class InterceptPipeline
+{
+    private readonly InterceptionContext _interceptionContext;
+    private readonly Func<Task> _inner;
+
+    public InterceptPipeline(InterceptionContext interceptionContext, Func<Task> inner)
+    {
+        _interceptionContext = interceptionContext;
+        _inner = inner;
+    }
+
+    public async Task Execute(IEnumerable<PipelineStep> steps)
+    {
+        var temp = new LinkedList<PipelineStep>(steps);
+        await ExecuteStep(temp.First);
+    }
+
+    private async Task ExecuteStep(LinkedListNode<PipelineStep>? current)
+    {
+        if (current is null)
+        {
+            await _inner().ConfigureAwait(false);
+            return;
+        }
+
+        var next = current.Next;
+        var step = current.Value;
+        var context = new AspectContext(method: _interceptionContext.Method, triggerAttribute: step.TriggerAttribute);
+
+        await step.Aspect.Invoke(context, () => ExecuteStep(next)).ConfigureAwait(false);
+    }
+}

--- a/src/SelfService/Domain/Aspectly/MethodInterceptor.cs
+++ b/src/SelfService/Domain/Aspectly/MethodInterceptor.cs
@@ -1,0 +1,67 @@
+using System.Reflection;
+using Castle.DynamicProxy;
+
+namespace SelfService.Domain.Aspectly;
+
+internal class InterceptionContext
+{
+    public InterceptionContext(MethodInfo method)
+    {
+        Method = method;
+    }
+
+    public MethodInfo Method { get; }
+}
+
+internal class MethodInterceptor : AsyncInterceptorBase
+{
+    private readonly PipelineStepFactory _pipelineStepFactory;
+
+    public MethodInterceptor(PipelineStepFactory pipelineStepFactory)
+    {
+        _pipelineStepFactory = pipelineStepFactory;
+    }
+
+    protected override async Task InterceptAsync(
+        IInvocation invocation,
+        IInvocationProceedInfo proceedInfo,
+        Func<IInvocation, IInvocationProceedInfo, Task> proceed
+    )
+    {
+        var interceptedMethod = invocation.MethodInvocationTarget;
+        var interceptionContext = new InterceptionContext(interceptedMethod);
+
+        var pipeline = new InterceptPipeline(
+            interceptionContext: interceptionContext,
+            inner: () => proceed(invocation, proceedInfo)
+        );
+
+        var steps = _pipelineStepFactory.GetPipelineStepsFor(interceptedMethod);
+        await pipeline.Execute(steps);
+    }
+
+    protected override async Task<TResult> InterceptAsync<TResult>(
+        IInvocation invocation,
+        IInvocationProceedInfo proceedInfo,
+        Func<IInvocation, IInvocationProceedInfo, Task<TResult>> proceed
+    )
+    {
+        var interceptedMethod = invocation.MethodInvocationTarget;
+        var interceptionContext = new InterceptionContext(interceptedMethod);
+
+        TResult? result = default;
+
+        var pipeline = new InterceptPipeline(
+            interceptionContext: interceptionContext,
+            inner: async () =>
+            {
+                result = await proceed(invocation, proceedInfo);
+            }
+        );
+
+        var steps = _pipelineStepFactory.GetPipelineStepsFor(interceptedMethod);
+        await pipeline.Execute(steps);
+
+        return result!;
+    }
+}

--- a/src/SelfService/Domain/Aspectly/PipelineStepFactory.cs
+++ b/src/SelfService/Domain/Aspectly/PipelineStepFactory.cs
@@ -1,0 +1,36 @@
+using System.Reflection;
+
+namespace SelfService.Domain.Aspectly;
+
+internal class PipelineStepFactory
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly AspectRegistry _aspectRegistry;
+
+    public PipelineStepFactory(IServiceProvider serviceProvider, AspectRegistry aspectRegistry)
+    {
+        _serviceProvider = serviceProvider;
+        _aspectRegistry = aspectRegistry;
+    }
+
+    public AnnotatedServiceRegistration? GetRegistrationFor(MethodInfo method)
+    {
+        return _aspectRegistry.GetAspectRegistrationFor(method);
+    }
+
+    public IEnumerable<PipelineStep> GetPipelineStepsFor(MethodInfo method)
+    {
+        var registration = GetRegistrationFor(method);
+
+        if (registration is null)
+        {
+            return Enumerable.Empty<PipelineStep>();
+        }
+
+        return registration.Duno.Select(
+            x => new PipelineStep(aspect: CreateAspect(x.AspectType), triggerAttribute: x.Attribute)
+        );
+    }
+
+    public IAspect CreateAspect(Type aspectType) => (IAspect)_serviceProvider.GetRequiredService(aspectType);
+}

--- a/src/SelfService/Domain/Aspectly/PipelineSteps.cs
+++ b/src/SelfService/Domain/Aspectly/PipelineSteps.cs
@@ -1,0 +1,13 @@
+namespace SelfService.Domain.Aspectly;
+
+internal class PipelineStep
+{
+    public PipelineStep(IAspect aspect, Attribute triggerAttribute)
+    {
+        Aspect = aspect;
+        TriggerAttribute = triggerAttribute;
+    }
+
+    public IAspect Aspect { get; private set; }
+    public Attribute TriggerAttribute { get; private set; }
+}

--- a/src/SelfService/Domain/Aspectly/README.md
+++ b/src/SelfService/Domain/Aspectly/README.md
@@ -1,0 +1,4 @@
+Aspectly is a C# Framework for writing Aspect Oriented Programming.
+It is originally created by Jens Andersen and available as a NuGet package with documentation here: https://github.com/jensandresen/aspectly
+
+Due to lack of maintenance leading to security issues, we have transferred what was necessary for our code to work.

--- a/src/SelfService/Domain/Aspectly/ServiceCollectionExtensions.cs
+++ b/src/SelfService/Domain/Aspectly/ServiceCollectionExtensions.cs
@@ -1,0 +1,107 @@
+using SelfService.Domain.Aspectly;
+using Castle.DynamicProxy;
+
+namespace Microsoft.Extensions.DependencyInjection;
+
+public static class ServiceCollectionExtensions
+{
+    private static readonly ProxyGenerator _proxyGenerator = new ProxyGenerator();
+
+    private static bool IsSupportedServiceDescriptor(ServiceDescriptor serviceDescriptor)
+    {
+        if (serviceDescriptor.ImplementationFactory != null)
+        {
+            return false;
+        }
+
+        if (serviceDescriptor.ImplementationInstance != null)
+        {
+            return false;
+        }
+
+        if (!serviceDescriptor.ServiceType.IsInterface)
+        {
+            return false;
+        }
+
+        if (serviceDescriptor.ImplementationType == null)
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    public static void RewireWithAspects(this IServiceCollection services, Action<IAspectOptions>? options = null)
+    {
+        var aspectRegistry = new AspectRegistry();
+        services.AddSingleton(aspectRegistry);
+
+        var optionsBuilder = new AspectOptionsBuilder();
+        options?.Invoke(optionsBuilder);
+
+        foreach (var map in optionsBuilder.Maps)
+        {
+            aspectRegistry.RegisterAspectTrigger(map.Attribute, map.Aspect);
+        }
+
+        foreach (var aspectType in aspectRegistry.RegisteredAspectTypes)
+        {
+            services.AddTransient(aspectType);
+        }
+
+        var descriptorsOfAnnotatedServices = services
+            .Where(IsSupportedServiceDescriptor)
+            .Where(x => aspectRegistry.HasTriggers(x.ImplementationType!))
+            .ToArray();
+
+        foreach (var serviceDescriptor in descriptorsOfAnnotatedServices)
+        {
+            aspectRegistry.RegisterAnnotatedService(serviceDescriptor.ImplementationType!);
+        }
+
+        // remove current service registrations
+        foreach (var serviceDescriptor in descriptorsOfAnnotatedServices)
+        {
+            services.Remove(serviceDescriptor);
+        }
+
+        // add service descriptor for implementation types
+        foreach (var serviceDescriptor in descriptorsOfAnnotatedServices)
+        {
+            services.Add(
+                ServiceDescriptor.Describe(
+                    serviceType: serviceDescriptor.ImplementationType!,
+                    implementationType: serviceDescriptor.ImplementationType!,
+                    lifetime: serviceDescriptor.Lifetime
+                )
+            );
+        }
+
+        // add new service descriptor with proxy factory
+        foreach (var serviceDescriptor in descriptorsOfAnnotatedServices)
+        {
+            var implementationType = serviceDescriptor.ImplementationType!;
+            var lifetime = serviceDescriptor.Lifetime;
+            var serviceType = serviceDescriptor.ServiceType;
+
+            services.Add(
+                ServiceDescriptor.Describe(
+                    serviceType: serviceType,
+                    provider =>
+                    {
+                        var myClass = provider.GetRequiredService(implementationType);
+                        var interceptor = new MethodInterceptor(new PipelineStepFactory(provider, aspectRegistry));
+
+                        return _proxyGenerator.CreateInterfaceProxyWithTargetInterface(
+                            interfaceToProxy: serviceType,
+                            target: myClass,
+                            new IAsyncInterceptor[] { interceptor }
+                        );
+                    },
+                    lifetime
+                )
+            );
+        }
+    }
+}

--- a/src/SelfService/Infrastructure/Messaging/OutboxEnqueuerAspect.cs
+++ b/src/SelfService/Infrastructure/Messaging/OutboxEnqueuerAspect.cs
@@ -1,6 +1,6 @@
-﻿using Aspectly;
-using Dafda.Outbox;
+﻿using Dafda.Outbox;
 using SelfService.Domain.Models;
+using SelfService.Domain.Aspectly;
 using SelfService.Infrastructure.Persistence;
 
 namespace SelfService.Infrastructure.Messaging;

--- a/src/SelfService/Infrastructure/Persistence/TransactionalAspect.cs
+++ b/src/SelfService/Infrastructure/Persistence/TransactionalAspect.cs
@@ -1,5 +1,4 @@
-﻿using Aspectly;
-using SelfService.Configuration;
+﻿using SelfService.Domain.Aspectly;
 
 namespace SelfService.Infrastructure.Persistence;
 

--- a/src/SelfService/SelfService.csproj
+++ b/src/SelfService/SelfService.csproj
@@ -7,7 +7,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Aspectly" Version="1.0.0" />
       <PackageReference Include="AWSSDK.ECR" Version="3.7.200.34" />
       <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.201.39" />
       <PackageReference Include="Dafda" Version="0.11.4" />
@@ -22,6 +21,7 @@
       <PackageReference Include="prometheus-net.AspNetCore" Version="7.0.0" />
       <PackageReference Include="Serilog.AspNetCore" Version="6.1.0" />
       <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
+      <PackageReference Include="Castle.Core.AsyncInterceptor" Version="2.0.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/SelfService/SelfService.csproj
+++ b/src/SelfService/SelfService.csproj
@@ -21,6 +21,7 @@
       <PackageReference Include="prometheus-net.AspNetCore" Version="7.0.0" />
       <PackageReference Include="Serilog.AspNetCore" Version="6.1.0" />
       <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
+      <PackageReference Include="Castle.Core" Version="5.1.1" />
       <PackageReference Include="Castle.Core.AsyncInterceptor" Version="2.1.0" />
     </ItemGroup>
 

--- a/src/SelfService/SelfService.csproj
+++ b/src/SelfService/SelfService.csproj
@@ -21,7 +21,7 @@
       <PackageReference Include="prometheus-net.AspNetCore" Version="7.0.0" />
       <PackageReference Include="Serilog.AspNetCore" Version="6.1.0" />
       <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
-      <PackageReference Include="Castle.Core.AsyncInterceptor" Version="2.0.0" />
+      <PackageReference Include="Castle.Core.AsyncInterceptor" Version="2.1.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/SelfService/SelfService.csproj
+++ b/src/SelfService/SelfService.csproj
@@ -13,10 +13,10 @@
       <PackageReference Include="JsonSchema.Net" Version="5.2.5" />
       <PackageReference Include="JsonSchema.Net.DataGeneration" Version="1.1.0" />
       <PackageReference Include="LibGit2Sharp" Version="0.30.0" />
-      <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.3" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.18" />
       <PackageReference Include="Microsoft.Identity.Web" Version="1.25.10" />
       <PackageReference Include="Microsoft.OpenApi" Version="1.6.3" />
-      <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="7.0.1" />
+      <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="7.0.18" />
       <PackageReference Include="prometheus-net" Version="7.0.0" />
       <PackageReference Include="prometheus-net.AspNetCore" Version="7.0.0" />
       <PackageReference Include="Serilog.AspNetCore" Version="6.1.0" />


### PR DESCRIPTION
closes dfds/cloudplatform/issues/2913

- Copy Aspectly library code into our project.
- Update EntityFramework versions.

# Additional Review Notes
This was the quickest way to claim ownership of Aspectly, instead of rebuilding it.
I still don't necessarily like what it does -- or at least I don't feel it is needed -- but now we can keep it up to date and prevent security issues whilst we use it.
