### PR TITLE
Add resource linking and claim information

### DIFF
--- a/src/SelfService.Tests/Builders/CapabilityApplicationServiceBuilder.cs
+++ b/src/SelfService.Tests/Builders/CapabilityApplicationServiceBuilder.cs
@@ -49,6 +49,7 @@ public class CapabilityApplicationServiceBuilder
             logger: NullLogger<CapabilityApplicationService>.Instance,
             capabilityRepository: _capabilityRepository,
             kafkaTopicRepository: Mock.Of<IKafkaTopicRepository>(),
+            capabilityClaimRepository: Mock.Of<ICapabilityClaimRepository>(),
             kafkaClusterAccessRepository: Mock.Of<IKafkaClusterAccessRepository>(),
             ticketingSystem: Mock.Of<ITicketingSystem>(),
             systemTime: SystemTime.Default,

--- a/src/SelfService/Application/CapabilityApplicationService.cs
+++ b/src/SelfService/Application/CapabilityApplicationService.cs
@@ -14,6 +14,7 @@ public class CapabilityApplicationService : ICapabilityApplicationService
     private readonly ICapabilityRepository _capabilityRepository;
     private readonly IKafkaTopicRepository _kafkaTopicRepository;
     private readonly IKafkaClusterAccessRepository _kafkaClusterAccessRepository;
+    private readonly ICapabilityClaimRepository _capabilityClaimRepository;
     private readonly ITicketingSystem _ticketingSystem;
     private readonly SystemTime _systemTime;
     private readonly ISelfServiceJsonSchemaService _selfServiceJsonSchemaService;
@@ -26,6 +27,7 @@ public class CapabilityApplicationService : ICapabilityApplicationService
         ICapabilityRepository capabilityRepository,
         IKafkaTopicRepository kafkaTopicRepository,
         IKafkaClusterAccessRepository kafkaClusterAccessRepository,
+        ICapabilityClaimRepository capabilityClaimRepository,
         ITicketingSystem ticketingSystem,
         SystemTime systemTime,
         ISelfServiceJsonSchemaService selfServiceJsonSchemaService,
@@ -35,6 +37,7 @@ public class CapabilityApplicationService : ICapabilityApplicationService
         _logger = logger;
         _capabilityRepository = capabilityRepository;
         _kafkaTopicRepository = kafkaTopicRepository;
+        _capabilityClaimRepository = capabilityClaimRepository;
         _kafkaClusterAccessRepository = kafkaClusterAccessRepository;
         _ticketingSystem = ticketingSystem;
         _systemTime = systemTime;
@@ -320,5 +323,45 @@ public class CapabilityApplicationService : ICapabilityApplicationService
     {
         var configLevelInfo = _configurationLevelService.ComputeConfigurationLevel(capabilityId);
         return configLevelInfo;
+    }
+
+    public async Task<bool> CheckClaim(CapabilityId capabilityId, string claimType)
+    {
+        if (
+            ListPossibleClaims().Any(co => co.ClaimType == claimType)
+            && await _capabilityClaimRepository.CheckClaim(capabilityId, claimType)
+        )
+        {
+            return true;
+        }
+        return false;
+    }
+
+    public async Task<List<CapabilityClaim>> GetAllClaims(CapabilityId capabilityId)
+    {
+        return await _capabilityClaimRepository.GetAll(capabilityId);
+    }
+
+    [TransactionalBoundary, Outboxed]
+    public async Task<CapabilityClaimId> AddClaim(CapabilityId capabilityId, string claimType, UserId userId)
+    {
+        var claimID = new CapabilityClaimId(Guid.NewGuid());
+        var claim = new CapabilityClaim(claimID, claimType, capabilityId, DateTime.Now, userId);
+        await _capabilityClaimRepository.Add(claim);
+        return claim.Id;
+    }
+
+    /*
+     * [2024-07-22] andfris: Temporary solution
+     * The following claims should be stored in a database rather than in code.
+     * This is a temporary solution to get the feature up and running quickly.
+     * If the feature is to be kept, the claims should be moved to a database.
+     */
+    public List<CapabilityClaimOption> ListPossibleClaims()
+    {
+        return new List<CapabilityClaimOption>
+        {
+            new CapabilityClaimOption(claimType: "snyk", claimDescription: "Code is integrating with Snyk"),
+        };
     }
 }

--- a/src/SelfService/Application/ICapabilityApplicationService.cs
+++ b/src/SelfService/Application/ICapabilityApplicationService.cs
@@ -33,4 +33,9 @@ public interface ICapabilityApplicationService
     Task<string> GetJsonMetadata(CapabilityId capabilityId);
     Task<bool> DoesOnlyModifyRequiredProperties(string jsonMetadata, CapabilityId capabilityId);
     Task<ConfigurationLevelInfo> GetConfigurationLevel(CapabilityId capabilityId);
+
+    Task<bool> CheckClaim(CapabilityId capabilityId, string claimType);
+    Task<List<CapabilityClaim>> GetAllClaims(CapabilityId capabilityId);
+    Task<CapabilityClaimId> AddClaim(CapabilityId capabilityId, string claimType, UserId userId);
+    List<CapabilityClaimOption> ListPossibleClaims();
 }

--- a/src/SelfService/Configuration/Domain.cs
+++ b/src/SelfService/Configuration/Domain.cs
@@ -57,7 +57,7 @@ public static class Domain
         builder.Services.AddTransient<ITeamCapabilityLinkingRepository, TeamCapabilityLinkingRepository>();
         builder.Services.AddTransient<TopVisitorsRepository>();
         builder.Services.AddTransient<IInvitationRepository, InvitationRepository>();
-        builder.Services.AddTransient<ICapabilityCalimRepository, CapabilityClaimRepository>();
+        builder.Services.AddTransient<ICapabilityClaimRepository, CapabilityClaimRepository>();
 
         // domain queries
         builder.Services.AddTransient<IKafkaTopicQuery, KafkaTopicQuery>();

--- a/src/SelfService/Domain/Models/CapabilityClaim.cs
+++ b/src/SelfService/Domain/Models/CapabilityClaim.cs
@@ -16,10 +16,9 @@ public class CapabilityClaim : AggregateRoot<CapabilityClaimId>
         RequestedBy = requestedBy;
         Claim = claim;
     }
+
     public CapabilityId CapabilityId { get; private set; }
     public string Claim { get; private set; }
     public DateTime RequestedAt { get; private set; }
     public string RequestedBy { get; private set; }
-    
-   
 }

--- a/src/SelfService/Domain/Models/CapabilityClaimId.cs
+++ b/src/SelfService/Domain/Models/CapabilityClaimId.cs
@@ -18,7 +18,7 @@ public class CapabilityClaimId : ValueObject
     {
         return _value.ToString("D");
     }
-    
+
     public static CapabilityClaimId New() => new CapabilityClaimId(Guid.NewGuid());
 
     public static CapabilityClaimId Parse(string? text)

--- a/src/SelfService/Domain/Models/CapabilityClaimOption.cs
+++ b/src/SelfService/Domain/Models/CapabilityClaimOption.cs
@@ -1,0 +1,13 @@
+namespace SelfService.Domain.Models;
+
+public class CapabilityClaimOption
+{
+    public CapabilityClaimOption(string claimType, string claimDescription)
+    {
+        ClaimType = claimType;
+        ClaimDescription = claimDescription;
+    }
+
+    public string ClaimType { get; private set; }
+    public string ClaimDescription { get; private set; }
+}

--- a/src/SelfService/Domain/Models/ICapabilityCalimRepository.cs
+++ b/src/SelfService/Domain/Models/ICapabilityCalimRepository.cs
@@ -1,6 +1,0 @@
-namespace SelfService.Domain.Models;
-
-public interface ICapabilityCalimRepository
-{
-    Task Add(CapabilityClaim claim);
-}

--- a/src/SelfService/Domain/Models/ICapabilityClaimRepository.cs
+++ b/src/SelfService/Domain/Models/ICapabilityClaimRepository.cs
@@ -1,0 +1,8 @@
+namespace SelfService.Domain.Models;
+
+public interface ICapabilityClaimRepository
+{
+    Task Add(CapabilityClaim claim);
+
+    Task<bool> CheckClaim(CapabilityId capabilityId, string claimType); // TODO: enum
+}

--- a/src/SelfService/Domain/Models/ICapabilityClaimRepository.cs
+++ b/src/SelfService/Domain/Models/ICapabilityClaimRepository.cs
@@ -1,3 +1,5 @@
+using System.Security.Claims;
+
 namespace SelfService.Domain.Models;
 
 public interface ICapabilityClaimRepository
@@ -5,4 +7,6 @@ public interface ICapabilityClaimRepository
     Task Add(CapabilityClaim claim);
 
     Task<bool> CheckClaim(CapabilityId capabilityId, string claimType); // TODO: enum
+
+    Task<List<CapabilityClaim>> GetAll(CapabilityId capabilityId);
 }

--- a/src/SelfService/Domain/Models/ICapabilityClaimService.cs
+++ b/src/SelfService/Domain/Models/ICapabilityClaimService.cs
@@ -1,8 +1,0 @@
-namespace SelfService.Domain.Models;
-
-public interface ICapabilityClaimService
-{
-    Task<CapabilityClaimId> Add(CapabilityId capabilityId, string requestClaim, UserId userId);
-
-    Task<bool> CheckClaimed(CapabilityId capabilityId, string claimType);
-}

--- a/src/SelfService/Domain/Models/ICapabilityClaimService.cs
+++ b/src/SelfService/Domain/Models/ICapabilityClaimService.cs
@@ -3,4 +3,6 @@ namespace SelfService.Domain.Models;
 public interface ICapabilityClaimService
 {
     Task<CapabilityClaimId> Add(CapabilityId capabilityId, string requestClaim, UserId userId);
+
+    Task<bool> CheckClaimed(CapabilityId capabilityId, string claimType);
 }

--- a/src/SelfService/Domain/Services/AuthorizationService.cs
+++ b/src/SelfService/Domain/Services/AuthorizationService.cs
@@ -266,4 +266,9 @@ public class AuthorizationService : IAuthorizationService
 
         return (kafkaTopic.IsPrivate && isMember) || isCloudEngineer || !kafkaTopic.IsPrivate;
     }
+
+    public async Task<bool> CanClaim(UserId userId, CapabilityId capabilityId)
+    {
+        return await _membershipQuery.HasActiveMembership(userId, capabilityId);
+    }
 }

--- a/src/SelfService/Domain/Services/IAuthorizationService.cs
+++ b/src/SelfService/Domain/Services/IAuthorizationService.cs
@@ -35,4 +35,5 @@ public interface IAuthorizationService
     Task<bool> CanInviteToCapability(UserId userId, CapabilityId capabilityId);
     Task<bool> CanSeeAwsAccountId(PortalUser portalUser, CapabilityId capabilityId);
     Task<bool> CanRetryCreatingMessageContract(PortalUser portalUser, MessageContractId messageContractId);
+    Task<bool> CanClaim(UserId userId, CapabilityId capabilityId);
 }

--- a/src/SelfService/Infrastructure/Api/Capabilities/CapabilityClaimApiResource.cs
+++ b/src/SelfService/Infrastructure/Api/Capabilities/CapabilityClaimApiResource.cs
@@ -1,0 +1,37 @@
+using System.Text.Json.Serialization;
+using Confluent.Kafka;
+
+namespace SelfService.Infrastructure.Api.Capabilities;
+
+public class CapabilityClaimApiResource
+{
+    public string Claim { get; set; }
+    public DateTime? ClaimedAt { get; set; }
+    public string ClaimDescription { get; set; }
+
+    [JsonPropertyName("_links")]
+    public CapabilityClaimLinks Links { get; set; }
+
+    public class CapabilityClaimLinks
+    {
+        public ResourceLink? Claim { get; set; }
+
+        public CapabilityClaimLinks(ResourceLink? claim)
+        {
+            Claim = claim;
+        }
+    }
+
+    public CapabilityClaimApiResource(
+        string claim,
+        string claimDescription,
+        DateTime? claimedAt,
+        CapabilityClaimLinks links
+    )
+    {
+        Claim = claim;
+        ClaimDescription = claimDescription;
+        ClaimedAt = claimedAt;
+        Links = links;
+    }
+}

--- a/src/SelfService/Infrastructure/Api/Capabilities/CapabilityClaimListApiResource.cs
+++ b/src/SelfService/Infrastructure/Api/Capabilities/CapabilityClaimListApiResource.cs
@@ -1,0 +1,27 @@
+using System.Text.Json.Serialization;
+
+namespace SelfService.Infrastructure.Api.Capabilities;
+
+public class CapabilityClaimListApiResource
+{
+    public List<CapabilityClaimApiResource> Claims { get; set; }
+
+    [JsonPropertyName("_links")]
+    public CapabilityClaimListLinks Links { get; set; }
+
+    public class CapabilityClaimListLinks
+    {
+        public ResourceLink Self { get; set; }
+
+        public CapabilityClaimListLinks(ResourceLink self)
+        {
+            Self = self;
+        }
+    }
+
+    public CapabilityClaimListApiResource(List<CapabilityClaimApiResource> claims, CapabilityClaimListLinks links)
+    {
+        Claims = claims;
+        Links = links;
+    }
+}

--- a/src/SelfService/Infrastructure/Api/Capabilities/NewCapabilityClaimRequest.cs
+++ b/src/SelfService/Infrastructure/Api/Capabilities/NewCapabilityClaimRequest.cs
@@ -4,7 +4,6 @@ namespace SelfService.Infrastructure.Api.Capabilities;
 
 public class NewCapabilityClaimRequest
 {
-        [Required]
-        public string? claim { get; set; } = null;
-    
+    [Required]
+    public string? claim { get; set; } = null;
 }

--- a/src/SelfService/Infrastructure/Persistence/CapabilityClaimRepository.cs
+++ b/src/SelfService/Infrastructure/Persistence/CapabilityClaimRepository.cs
@@ -1,19 +1,30 @@
+using Microsoft.EntityFrameworkCore;
 using SelfService.Domain.Models;
 
 namespace SelfService.Infrastructure.Persistence.Queries;
 
-public class CapabilityClaimRepository : ICapabilityCalimRepository
+public class CapabilityClaimRepository : ICapabilityClaimRepository
 {
     private readonly SelfServiceDbContext _dbContext;
-    
+
     public CapabilityClaimRepository(SelfServiceDbContext dbContext)
     {
         _dbContext = dbContext;
     }
-    
+
     public async Task Add(CapabilityClaim claim)
     {
         await _dbContext.CapabilityClaims.AddAsync(claim);
         await _dbContext.SaveChangesAsync();
+    }
+
+    public async Task<bool> CheckClaim(CapabilityId capabilityId, string claimType)
+    {
+        return await _dbContext.CapabilityClaims.AnyAsync(c => c.CapabilityId == capabilityId && c.Claim == claimType);
+    }
+
+    public async Task<List<CapabilityClaim>> GetAll(CapabilityId capabilityId)
+    {
+        return await _dbContext.CapabilityClaims.Where(x => x.CapabilityId == capabilityId).ToListAsync();
     }
 }

--- a/src/SelfService/Infrastructure/Persistence/Converters/CapabilityClaimIdConverter.cs
+++ b/src/SelfService/Infrastructure/Persistence/Converters/CapabilityClaimIdConverter.cs
@@ -11,5 +11,4 @@ public class CapabilityClaimIdConverter : ValueConverter<CapabilityClaimId, Guid
 
     private static Expression<Func<CapabilityClaimId, Guid>> ToDatabaseType => id => id;
     private static Expression<Func<Guid, CapabilityClaimId>> FromDatabaseType => value => value;
-    
 }

--- a/src/SelfService/Infrastructure/Persistence/SelfServiceDbContext.cs
+++ b/src/SelfService/Infrastructure/Persistence/SelfServiceDbContext.cs
@@ -66,7 +66,6 @@ public class SelfServiceDbContext : DbContext
     public DbSet<TeamCapabilityLink> TeamCapabilityLinks => Set<TeamCapabilityLink>();
     public DbSet<Invitation> Invitations => Set<Invitation>();
     public DbSet<CapabilityClaim> CapabilityClaims => Set<CapabilityClaim>();
-    
 
     protected override void ConfigureConventions(ModelConfigurationBuilder configurationBuilder)
     {
@@ -119,9 +118,8 @@ public class SelfServiceDbContext : DbContext
         configurationBuilder.Properties<MessageContractStatus>().HaveConversion<MessageContractStatusConverter>();
 
         configurationBuilder.Properties<ECRRepositoryId>().HaveConversion<ECRRepositoryIdConverter>();
-        
+
         configurationBuilder.Properties<TeamId>().HaveConversion<ValueObjectGuidConverter<TeamId>>();
-        
 
         configurationBuilder
             .Properties<TeamCapabilityLinkId>()
@@ -393,7 +391,7 @@ public class SelfServiceDbContext : DbContext
             cfg.Property(x => x.CreatedAt);
             cfg.Property(x => x.ModifiedAt);
         });
-        
+
         modelBuilder.Entity<CapabilityClaim>(cfg =>
         {
             cfg.ToTable("CapabilityClaim");


### PR DESCRIPTION
# Additional Review Notes
Extends the existing suggested solution with the following:
- ClaimsService for wrapping database interactions in additional logic
- ResourceLinks for following our API standard
- Purely URL-based claims adding, rather than sending post-body
- Descriptions to the known claims
- A list of known claims

The idea is to make the frontend completely ignorant of which claims exists, and simply render things.