### PR TITLE
Feature/capability aws vpc information

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       - SEED_CSV_SEPARATOR=;          # NOTE: csv delimiter overwritten
       - LOCAL_DEVELOPMENT=1           # will CREATE DATABASE ${PGDATABASE} every time
       - PGDATABASE=db                 # database name
-      - PGHOST=database               # docker-compose service name
+      - PGHOST=database               # docker compose service name
       - PGUSER=postgres               # same as above
       - PGPASSWORD=p                  # same as above
       - PGSSLMODE=disable             # ignore SSLMODE for local development

--- a/integrationtest/docker-compose.yml
+++ b/integrationtest/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       - SEED_CSV_SEPARATOR=; # NOTE: csv delimiter overwritten
       - LOCAL_DEVELOPMENT=1 # will CREATE DATABASE ${PGDATABASE} every time
       - PGDATABASE=db # database name
-      - PGHOST=database # docker-compose service name
+      - PGHOST=database # docker compose service name
       - PGUSER=postgres # same as above
       - PGPASSWORD=p # same as above
       - PGSSLMODE=disable # ignore SSLMODE for local development

--- a/integrationtest/run.sh
+++ b/integrationtest/run.sh
@@ -12,7 +12,7 @@ rm -Rf ${BIN_DIR}
 mkdir ${BIN_DIR}
 
 echo -e "\e[35mClosing any previous containers...\e[0m"
-docker-compose -p ${INTEGRATION_TEST_NAME} down -v
+docker compose -p ${INTEGRATION_TEST_NAME} down -v
 
 echo -e "\e[35mCopying test dlls...\e[0m"
 dotnet publish \
@@ -25,12 +25,12 @@ dotnet publish \
     ../src/${TEST_PROJECT_NAME}/${TEST_PROJECT_NAME}.csproj
 
 echo -e "\e[35mSpinning up containers...\e[0m"
-docker-compose -p ${INTEGRATION_TEST_NAME} up --build -d
+docker compose -p ${INTEGRATION_TEST_NAME} up --build -d
 
 echo -e "\e[35mGetting port of database container...\e[0m"
-PORT=$(docker-compose -p ${INTEGRATION_TEST_NAME} port database 5432 | awk -F : '{print $2}')
+PORT=$(docker compose -p ${INTEGRATION_TEST_NAME} port database 5432 | awk -F : '{print $2}')
 
-MIGRATION_CONTAINER_NAME=$(docker-compose -p ${INTEGRATION_TEST_NAME} ps --all | grep -i 'db-migration' | awk '{print $1}')
+MIGRATION_CONTAINER_NAME=$(docker compose -p ${INTEGRATION_TEST_NAME} ps --all | grep -i 'db-migration' | awk '{print $1}')
 
 echo "container name: ${MIGRATION_CONTAINER_NAME}"
 
@@ -44,7 +44,7 @@ then
 
    echo ""
    echo -e "\e[33mClosing containers...\e[0m"
-   docker-compose -p ${INTEGRATION_TEST_NAME} down -v
+   docker compose -p ${INTEGRATION_TEST_NAME} down -v
 
    exit -1
 fi
@@ -62,7 +62,7 @@ dotnet test \
 LAST_EXIT_CODE=$?
 
 echo -e "\e[35mClosing containers...\e[0m"
-docker-compose -p ${INTEGRATION_TEST_NAME} down -v
+docker compose -p ${INTEGRATION_TEST_NAME} down -v
 
 echo -e "\e[35mCopying test result...\e[0m"
 cp ${PWD}/TestResults/testresults.trx $OUTPUT_DIR_TESTRESULTS/integration_testresults.trx

--- a/src/SelfService/Application/AwsEC2QueriesApplicationService.cs
+++ b/src/SelfService/Application/AwsEC2QueriesApplicationService.cs
@@ -1,0 +1,111 @@
+using Amazon;
+using Amazon.SecurityToken;
+using Amazon.SecurityToken.Model;
+using Amazon.Runtime;
+using Amazon.EC2;
+using Amazon.EC2.Model;
+using SelfService.Domain.Models;
+
+namespace SelfService.Application;
+
+public class AwsEC2QueriesApplicationService : IAwsEC2QueriesApplicationService
+{
+    public async Task<List<VPCInformation>> GetVPCsAsync(string accountId)
+    {
+        var allVpcs = new List<VPCInformation>();
+
+        string RoleArn = $"arn:aws:iam::{accountId}:role/ReadVPCPeerings";
+
+        var regions = new List<RegionEndpoint>
+        {
+            RegionEndpoint.EUCentral1,
+            RegionEndpoint.EUWest1,
+            RegionEndpoint.EUWest2,
+            RegionEndpoint.USEast1,
+            RegionEndpoint.USWest1,
+        };
+
+        var temporaryCredentials = await AssumeRoleAsync(RoleArn, RegionEndpoint.EUCentral1);
+
+        foreach (var region in regions)
+        {
+            var ec2Client = new AmazonEC2Client(temporaryCredentials, region);
+            var vpcs = await DescribeVpcsAsync(ec2Client);
+
+            if (vpcs != null)
+            {
+                foreach (var vpc in vpcs)
+                {
+                    var VpcInformation = new VPCInformation
+                    {
+                        VpcId = vpc.VpcId,
+                        CidrBlock = vpc.CidrBlock,
+                        Region = region.SystemName
+                    };
+                    allVpcs.Add(VpcInformation);
+                }
+            }
+        }
+        return allVpcs;
+    }
+
+    static async Task<List<Vpc>> DescribeVpcsAsync(IAmazonEC2 ec2Client)
+    {
+        var result = new List<Vpc>();
+
+        try
+        {
+            var something = await ec2Client.DescribeVpcsAsync();
+            if (something.HttpStatusCode == System.Net.HttpStatusCode.OK)
+            {
+                foreach (var vpc in something.Vpcs)
+                {
+                    var describeTagsRequest = new DescribeTagsRequest
+                    {
+                        Filters = new List<Filter>
+                        {
+                            new Filter
+                            {
+                                Name = "resource-id",
+                                Values = new List<string> { vpc.VpcId }
+                            }
+                        }
+                    };
+                    var tagsResponse = await ec2Client.DescribeTagsAsync(describeTagsRequest);
+
+                    var hasPeeringTag = tagsResponse.Tags.Exists(tag => tag.Key == "Name" && tag.Value == "peering");
+                    if (hasPeeringTag)
+                    {
+                        result.Add(vpc);
+                    }
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            throw new Exception($"Error in region {ec2Client.Config.RegionEndpoint.SystemName}: {ex.Message}");
+        }
+        return result;
+    }
+
+    static async Task<AWSCredentials> AssumeRoleAsync(string roleArn, RegionEndpoint region)
+    {
+        using (var stsClient = new AmazonSecurityTokenServiceClient(RegionEndpoint.EUCentral1))
+        {
+            var assumeRoleRequest = new AssumeRoleRequest
+            {
+                RoleArn = roleArn,
+                RoleSessionName = "SelfserviceEC2Queries",
+            };
+
+            var assumeRoleResponse = await stsClient.AssumeRoleAsync(assumeRoleRequest);
+            var credentials = assumeRoleResponse.Credentials;
+
+            return new SessionAWSCredentials(
+                credentials.AccessKeyId,
+                credentials.SecretAccessKey,
+                credentials.SessionToken
+            );
+        }
+    }
+}

--- a/src/SelfService/Application/AwsEcrRepositoryApplicationService.cs
+++ b/src/SelfService/Application/AwsEcrRepositoryApplicationService.cs
@@ -49,7 +49,7 @@ public class AwsEcrRepositoryApplicationService : IAwsECRRepositoryApplicationSe
         if (accountId == null)
             throw new Exception("ECR_PULL_PERMISSION_AWS_ACCOUNT_ID environment variable is not set");
 
-        var newRepository = await client.CreateRepositoryAsync(
+        await client.CreateRepositoryAsync(
             new CreateRepositoryRequest
             {
                 ImageScanningConfiguration = new ImageScanningConfiguration() { ScanOnPush = true },

--- a/src/SelfService/Application/AwsEcrRepositoryApplicationService.cs
+++ b/src/SelfService/Application/AwsEcrRepositoryApplicationService.cs
@@ -1,11 +1,16 @@
 using Amazon;
 using Amazon.ECR;
 using Amazon.ECR.Model;
+using Amazon.SecurityToken;
+using Amazon.SecurityToken.Model;
+using Amazon.Runtime;
 
 namespace SelfService.Application;
 
 public class AwsEcrRepositoryApplicationService : IAwsECRRepositoryApplicationService
 {
+    private IAwsRoleManger awsRoleManager => new AwsRoleManager();
+
     private string GetPermissionJson(string awsAccountId)
     {
         return $$"""
@@ -31,9 +36,9 @@ public class AwsEcrRepositoryApplicationService : IAwsECRRepositoryApplicationSe
                  """;
     }
 
-    private AmazonECRClient NewAwsECRClient()
+    private AmazonECRClient NewAwsECRClient(AWSCredentials credentials)
     {
-        return new AmazonECRClient(new AmazonECRConfig { RegionEndpoint = RegionEndpoint.EUCentral1, });
+        return new AmazonECRClient(credentials, new AmazonECRConfig { RegionEndpoint = RegionEndpoint.EUCentral1, });
     }
 
     /// <summary>
@@ -44,7 +49,10 @@ public class AwsEcrRepositoryApplicationService : IAwsECRRepositoryApplicationSe
     /// </summary>
     public async Task CreateECRRepo(string name)
     {
-        var client = NewAwsECRClient();
+        var roleArn = "arn:aws:iam::579478677147:role/CreateECRRepos";
+        var credentials = await awsRoleManager.AssumeRoleAsync(roleArn, RegionEndpoint.EUCentral1);
+        var client = NewAwsECRClient(credentials);
+
         var accountId = Environment.GetEnvironmentVariable("ECR_PULL_PERMISSION_AWS_ACCOUNT_ID");
         if (accountId == null)
             throw new Exception("ECR_PULL_PERMISSION_AWS_ACCOUNT_ID environment variable is not set");
@@ -77,13 +85,19 @@ public class AwsEcrRepositoryApplicationService : IAwsECRRepositoryApplicationSe
     /// </summary>
     public async Task DeleteECRRepo(string name)
     {
-        AmazonECRClient client = new(new AmazonECRConfig { RegionEndpoint = RegionEndpoint.EUCentral1, });
+        var roleArn = "arn:aws:iam::579478677147:role/CreateECRRepos";
+        var credentials = await awsRoleManager.AssumeRoleAsync(roleArn, RegionEndpoint.EUCentral1);
+        var client = NewAwsECRClient(credentials);
+
         await client.DeleteRepositoryAsync(new DeleteRepositoryRequest { RepositoryName = name, });
     }
 
     public async Task<List<string>> GetECRRepositories()
     {
-        var client = NewAwsECRClient();
+        var roleArn = "arn:aws:iam::579478677147:role/CreateECRRepos";
+        var credentials = await awsRoleManager.AssumeRoleAsync(roleArn, RegionEndpoint.EUCentral1);
+        var client = NewAwsECRClient(credentials);
+
         HashSet<string> repos = new();
         string? nextToken = null;
         do

--- a/src/SelfService/Application/AwsRoleManager.cs
+++ b/src/SelfService/Application/AwsRoleManager.cs
@@ -1,0 +1,30 @@
+using Amazon;
+using Amazon.SecurityToken;
+using Amazon.SecurityToken.Model;
+using Amazon.Runtime;
+
+namespace SelfService.Application;
+
+public class AwsRoleManager : IAwsRoleManger
+{
+    public async Task<AWSCredentials> AssumeRoleAsync(string roleArn, RegionEndpoint region)
+    {
+        using (var stsClient = new AmazonSecurityTokenServiceClient(region))
+        {
+            var assumeRoleRequest = new AssumeRoleRequest
+            {
+                RoleArn = roleArn,
+                RoleSessionName = "SelfserviceECRRequests",
+            };
+
+            var assumeRoleResponse = await stsClient.AssumeRoleAsync(assumeRoleRequest);
+            var credentials = assumeRoleResponse.Credentials;
+
+            return new SessionAWSCredentials(
+                credentials.AccessKeyId,
+                credentials.SecretAccessKey,
+                credentials.SessionToken
+            );
+        }
+    }
+}

--- a/src/SelfService/Application/CapabilityApplicationService.cs
+++ b/src/SelfService/Application/CapabilityApplicationService.cs
@@ -208,7 +208,6 @@ public class CapabilityApplicationService : ICapabilityApplicationService
 
     [TransactionalBoundary, Outboxed]
     public async Task ActOnPendingCapabilityDeletions()
-    /// FLUTTERSHY
     {
         using var _ = _logger.BeginScope(
             "{BackgroundJob} {CorrelationId}",

--- a/src/SelfService/Application/IAwsEC2QueriesApplicationService.cs
+++ b/src/SelfService/Application/IAwsEC2QueriesApplicationService.cs
@@ -1,0 +1,8 @@
+using SelfService.Domain.Models;
+
+namespace SelfService.Application;
+
+public interface IAwsEC2QueriesApplicationService
+{
+    Task<List<VPCInformation>> GetVPCsAsync(string accountId);
+}

--- a/src/SelfService/Application/IAwsRoleManager.cs
+++ b/src/SelfService/Application/IAwsRoleManager.cs
@@ -1,0 +1,9 @@
+using Amazon;
+using Amazon.Runtime;
+
+namespace SelfService.Application;
+
+public interface IAwsRoleManger
+{
+    Task<AWSCredentials> AssumeRoleAsync(string roleArn, RegionEndpoint region);
+}

--- a/src/SelfService/Configuration/Domain.cs
+++ b/src/SelfService/Configuration/Domain.cs
@@ -29,6 +29,7 @@ public static class Domain
         builder.Services.AddTransient<IMemberApplicationService, MemberApplicationService>();
         builder.Services.AddTransient<IPortalVisitApplicationService, PortalVisitApplicationService>();
         builder.Services.AddTransient<IAwsECRRepositoryApplicationService, AwsEcrRepositoryApplicationService>();
+        builder.Services.AddTransient<IAwsEC2QueriesApplicationService, AwsEC2QueriesApplicationService>();
         builder.Services.AddTransient<ITeamApplicationService, TeamApplicationService>();
         builder.Services.AddTransient<IInvitationApplicationService, InvitationApplicationService>();
 

--- a/src/SelfService/Domain/Models/AwsAccountInformation.cs
+++ b/src/SelfService/Domain/Models/AwsAccountInformation.cs
@@ -1,0 +1,17 @@
+using Amazon.EC2;
+using SelfService.Domain.Events;
+
+namespace SelfService.Domain.Models;
+
+public class AwsAccountInformation : AggregateRoot<AwsAccountId>
+{
+    public AwsAccountInformation(AwsAccountId id, CapabilityId capabilityId, List<VPCInformation> vpclist)
+        : base(id)
+    {
+        CapabilityId = capabilityId;
+        vpcs = vpclist;
+    }
+
+    public List<VPCInformation> vpcs { get; private set; } = new List<VPCInformation>();
+    public CapabilityId CapabilityId { get; private set; }
+}

--- a/src/SelfService/Domain/Models/VpcInformation.cs
+++ b/src/SelfService/Domain/Models/VpcInformation.cs
@@ -1,0 +1,13 @@
+namespace SelfService.Domain.Models;
+
+public class VPCInformation
+{
+    public string VpcId { get; set; } = null!;
+    public string CidrBlock { get; set; } = null!;
+    public string Region { get; set; } = null!;
+
+    public override string ToString()
+    {
+        return $"VPC ID: {VpcId}, CIDR Block: {CidrBlock}, Region: {Region}";
+    }
+}

--- a/src/SelfService/Domain/Services/AuthorizationService.cs
+++ b/src/SelfService/Domain/Services/AuthorizationService.cs
@@ -175,6 +175,16 @@ public class AuthorizationService : IAuthorizationService
             && await _awsAccountRepository.Exists(capabilityId);
     }
 
+    public async Task<bool> CanViewAwsAccount(UserId userId, AwsAccountId accountId)
+    {
+        var account = await _awsAccountRepository.Get(accountId);
+        if (account == null)
+        {
+            return false;
+        }
+        return await _membershipQuery.HasActiveMembership(userId, account.CapabilityId);
+    }
+
     public async Task<bool> CanRequestAwsAccount(UserId userId, CapabilityId capabilityId)
     {
         return await _membershipQuery.HasActiveMembership(userId, capabilityId)

--- a/src/SelfService/Infrastructure/Api/ApiResourceFactory.cs
+++ b/src/SelfService/Infrastructure/Api/ApiResourceFactory.cs
@@ -10,6 +10,7 @@ using SelfService.Infrastructure.Api.System;
 using SelfService.Infrastructure.Api.Teams;
 using SelfService.Infrastructure.Api.Invitations;
 using static SelfService.Infrastructure.Api.Method;
+using Amazon.EC2;
 
 namespace SelfService.Infrastructure.Api;
 
@@ -692,6 +693,32 @@ public class ApiResourceFactory
                         action: nameof(CapabilityController.GetCapabilityAwsAccount),
                         controller: GetNameOf<CapabilityController>(),
                         values: new { id = account.CapabilityId }
+                    ) ?? "",
+                    rel: "self",
+                    allow: allowedInteractions
+                )
+            )
+        );
+    }
+
+    public async Task<AwsAccountInformationApiResource> Convert(AwsAccountInformation information)
+    {
+        var allowedInteractions = Allow.None;
+        if (await _authorizationService.CanViewAwsAccount(CurrentUser, information.CapabilityId))
+        {
+            allowedInteractions += Get;
+        }
+        return new AwsAccountInformationApiResource(
+            id: information.Id,
+            capabilityId: information.CapabilityId,
+            vpcs: information.vpcs,
+            links: new AwsAccountInformationApiResource.AwsAccountInformationLinks(
+                self: new ResourceLink(
+                    href: _linkGenerator.GetUriByAction(
+                        httpContext: HttpContext,
+                        action: nameof(CapabilityController.GetCapabilityAwsAccountInformation),
+                        controller: GetNameOf<CapabilityController>(),
+                        values: new { id = information.CapabilityId }
                     ) ?? "",
                     rel: "self",
                     allow: allowedInteractions

--- a/src/SelfService/Infrastructure/Api/ApiResourceFactory.cs
+++ b/src/SelfService/Infrastructure/Api/ApiResourceFactory.cs
@@ -578,6 +578,27 @@ public class ApiResourceFactory
         );
     }
 
+    private async Task<ResourceLink> CreateAwsAccountInformationLinkFor(Capability capability)
+    {
+        var allowedInteractions = Allow.None;
+
+        if (await _authorizationService.CanViewAwsAccount(CurrentUser, capability.Id))
+        {
+            allowedInteractions += Get;
+        }
+
+        return new ResourceLink(
+            href: _linkGenerator.GetUriByAction(
+                httpContext: HttpContext,
+                action: nameof(CapabilityController.GetCapabilityAwsAccountInformation),
+                controller: GetNameOf<CapabilityController>(),
+                values: new { id = capability.Id }
+            ) ?? "",
+            rel: "related",
+            allow: allowedInteractions
+        );
+    }
+
     private async Task<ResourceLink> CreateAzureResourcesLinkFor(Capability capability)
     {
         var allowedInteractions = Allow.Get;
@@ -658,6 +679,7 @@ public class ApiResourceFactory
                 membershipApplications: await CreateMembershipApplicationsLinkFor(capability),
                 leaveCapability: await CreateLeaveCapabilityLinkFor(capability),
                 awsAccount: await CreateAwsAccountLinkFor(capability),
+                awsAccountInformation: await CreateAwsAccountInformationLinkFor(capability),
                 azureResources: await CreateAzureResourcesLinkFor(capability),
                 requestCapabilityDeletion: await CreateRequestDeletionLinkFor(capability),
                 cancelCapabilityDeletionRequest: await CreateCancelDeletionRequestLinkFor(capability),

--- a/src/SelfService/Infrastructure/Api/Capabilities/AwsAccountInformationApiResource.cs
+++ b/src/SelfService/Infrastructure/Api/Capabilities/AwsAccountInformationApiResource.cs
@@ -1,0 +1,37 @@
+using System.Text.Json.Serialization;
+using SelfService.Domain.Models;
+
+namespace SelfService.Infrastructure.Api.Capabilities;
+
+public class AwsAccountInformationApiResource
+{
+    public string Id { get; set; }
+    public string? CapabilityId { get; set; }
+    public List<VPCInformation>? vpcs { get; set; }
+
+    [JsonPropertyName("_links")]
+    public AwsAccountInformationLinks Links { get; set; }
+
+    public class AwsAccountInformationLinks
+    {
+        public ResourceLink Self { get; set; }
+
+        public AwsAccountInformationLinks(ResourceLink self)
+        {
+            Self = self;
+        }
+    }
+
+    public AwsAccountInformationApiResource(
+        string id,
+        string? capabilityId,
+        List<VPCInformation>? vpcs,
+        AwsAccountInformationLinks links
+    )
+    {
+        Id = id;
+        CapabilityId = capabilityId;
+        this.vpcs = vpcs;
+        Links = links;
+    }
+}

--- a/src/SelfService/Infrastructure/Api/Capabilities/CapabilityController.cs
+++ b/src/SelfService/Infrastructure/Api/Capabilities/CapabilityController.cs
@@ -33,6 +33,7 @@ public class CapabilityController : ControllerBase
     private readonly ISelfServiceJsonSchemaService _selfServiceJsonSchemaService;
     private readonly IInvitationApplicationService _invitationApplicationService;
     private readonly ICapabilityClaimRepository _capabilityClaimRepository;
+    private readonly IAwsEC2QueriesApplicationService _awsEC2QueriesApplicationService;
 
     public CapabilityController(
         ICapabilityMembersQuery membersQuery,
@@ -52,7 +53,8 @@ public class CapabilityController : ControllerBase
         ILogger<CapabilityController> logger,
         ITeamApplicationService teamApplicationService,
         IInvitationApplicationService invitationApplicationService,
-        ICapabilityClaimRepository capabilityClaimRepository
+        ICapabilityClaimRepository capabilityClaimRepository,
+        IAwsEC2QueriesApplicationService awsEC2QueriesApplicationService
     )
     {
         _membersQuery = membersQuery;
@@ -73,6 +75,7 @@ public class CapabilityController : ControllerBase
         _teamApplicationService = teamApplicationService;
         _invitationApplicationService = invitationApplicationService;
         _capabilityClaimRepository = capabilityClaimRepository;
+        _awsEC2QueriesApplicationService = awsEC2QueriesApplicationService;
     }
 
     [HttpGet("")]
@@ -280,6 +283,34 @@ public class CapabilityController : ControllerBase
         {
             return Conflict();
         }
+    }
+
+    [HttpGet("{id:required}/awsaccount/information")]
+    [ProducesResponseType(typeof(AwsAccountApiResource), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized, "application/problem+json")]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound, "application/problem+json")]
+    public async Task<IActionResult> GetCapabilityAwsAccountInformation(string id)
+    {
+        if (!User.TryGetUserId(out var userId))
+            return Unauthorized();
+
+        if (!CapabilityId.TryParse(id, out var capabilityId))
+            return NotFound();
+
+        if (!await _capabilityRepository.Exists(capabilityId))
+            return NotFound();
+
+        if (!await _authorizationService.CanViewAwsAccount(userId, capabilityId))
+            return Unauthorized();
+
+        var account = await _awsAccountRepository.FindBy(capabilityId);
+        if (account is null)
+            return NotFound();
+
+        var vpcs = _awsEC2QueriesApplicationService.GetVPCsAsync(account.Id.ToString());
+
+        var accountInformation = new AwsAccountInformation(account.Id, capabilityId, await vpcs);
+        return Ok(await _apiResourceFactory.Convert(accountInformation));
     }
 
     [HttpGet("{id:required}/azureresources")]

--- a/src/SelfService/Infrastructure/Api/Capabilities/CapabilityDetailsApiResource.cs
+++ b/src/SelfService/Infrastructure/Api/Capabilities/CapabilityDetailsApiResource.cs
@@ -26,6 +26,7 @@ public class CapabilityDetailsApiResource
         public ResourceLink MembershipApplications { get; set; }
         public ResourceLink LeaveCapability { get; set; }
         public ResourceLink AwsAccount { get; set; }
+        public ResourceLink AwsAccountInformation { get; set; }
         public ResourceLink AzureResources { get; set; }
         public ResourceLink RequestCapabilityDeletion { get; set; }
         public ResourceLink CancelCapabilityDeletionRequest { get; set; }
@@ -45,6 +46,7 @@ public class CapabilityDetailsApiResource
             ResourceLink membershipApplications,
             ResourceLink leaveCapability,
             ResourceLink awsAccount,
+            ResourceLink awsAccountInformation,
             ResourceLink azureResources,
             ResourceLink requestCapabilityDeletion,
             ResourceLink cancelCapabilityDeletionRequest,
@@ -63,6 +65,7 @@ public class CapabilityDetailsApiResource
             MembershipApplications = membershipApplications;
             LeaveCapability = leaveCapability;
             AwsAccount = awsAccount;
+            AwsAccountInformation = awsAccountInformation;
             AzureResources = azureResources;
             RequestCapabilityDeletion = requestCapabilityDeletion;
             CancelCapabilityDeletionRequest = cancelCapabilityDeletionRequest;

--- a/src/SelfService/SelfService.csproj
+++ b/src/SelfService/SelfService.csproj
@@ -7,6 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+      <PackageReference Include="AWSSDK.EC2" Version="3.7.401.2" />
       <PackageReference Include="AWSSDK.ECR" Version="3.7.200.34" />
       <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.201.39" />
       <PackageReference Include="Dafda" Version="0.11.4" />


### PR DESCRIPTION
closes dfds/cloudplatform/issues/2936

Allow users to query for the information of aws accounts for a capability where they are a member.
This is a separate endpoint to not mess with existing functionality.
The new information endpoint only returns vpc peering information as it is.

# Additional Review Notes
Manually updated roles and permissions in the AWS console.
Rolls for capability aws accounts managed via terraform and updated accordingly
