### PR TITLE
Added API endpoints to membershipapplications controller

### DIFF
--- a/src/SelfService.Tests/Builders/MembershipApplicationServiceBuilder.cs
+++ b/src/SelfService.Tests/Builders/MembershipApplicationServiceBuilder.cs
@@ -16,6 +16,7 @@ public class MembershipApplicationServiceBuilder
     private ICapabilityRepository _capabilityRepository;
     private IAuthorizationService _authorizationService;
     private IInvitationRepository _invitationRepository;
+    private IMyCapabilitiesQuery _myCapabilitiesQuery;
 
     public MembershipApplicationServiceBuilder()
     {
@@ -24,6 +25,7 @@ public class MembershipApplicationServiceBuilder
         _capabilityRepository = Dummy.Of<ICapabilityRepository>();
         _authorizationService = Dummy.Of<IAuthorizationService>();
         _invitationRepository = Dummy.Of<IInvitationRepository>();
+        _myCapabilitiesQuery = Dummy.Of<IMyCapabilitiesQuery>();
     }
 
     public MembershipApplicationServiceBuilder WithMembershipRepository(IMembershipRepository membershipRepository)
@@ -69,7 +71,8 @@ public class MembershipApplicationServiceBuilder
             systemTime: SystemTime.Default,
             membershipQuery: Mock.Of<IMembershipQuery>(),
             membershipApplicationDomainService: Mock.Of<IMembershipApplicationDomainService>(),
-            invitationRepository: _invitationRepository
+            invitationRepository: _invitationRepository,
+            myCapabilitiesQuery: _myCapabilitiesQuery
         );
     }
 

--- a/src/SelfService/Application/IMembershipApplicationService.cs
+++ b/src/SelfService/Application/IMembershipApplicationService.cs
@@ -13,4 +13,5 @@ public interface IMembershipApplicationService
     Task RemoveMembershipApplication(MembershipApplicationId applicationId);
     Task LeaveCapability(CapabilityId capabilityId, UserId userId);
     Task JoinCapability(CapabilityId capabilityId, UserId userId);
+    Task<IEnumerable<MembershipApplication>> GetMembershipsApplicationsThatUserCanApprove(UserId userId);
 }

--- a/src/SelfService/Application/MembershipApplicationService.cs
+++ b/src/SelfService/Application/MembershipApplicationService.cs
@@ -299,8 +299,15 @@ public class MembershipApplicationService : IMembershipApplicationService
     {
         var capabilities = await _myCapabilitiesQuery.FindBy(userId);
         var memberships = await _membershipApplicationRepository.GetAll();
-        var membershipsThatUserCanApprove =
-            memberships.ToList().Where(x => capabilities.Any(cap => cap.Id == x.CapabilityId && x.Status == MembershipApplicationStatusOptions.PendingApprovals));
+        var membershipsThatUserCanApprove = memberships
+            .ToList()
+            .Where(
+                x =>
+                    capabilities.Any(
+                        cap =>
+                            cap.Id == x.CapabilityId && x.Status == MembershipApplicationStatusOptions.PendingApprovals
+                    )
+            );
 
         return membershipsThatUserCanApprove.ToList();
     }

--- a/src/SelfService/Domain/Models/IMembershipApplicationRepository.cs
+++ b/src/SelfService/Domain/Models/IMembershipApplicationRepository.cs
@@ -4,6 +4,7 @@ public interface IMembershipApplicationRepository
 {
     Task Add(MembershipApplication application);
     Task<MembershipApplication> Get(MembershipApplicationId id);
+    Task<IEnumerable<MembershipApplication>> GetAll();
     Task<IEnumerable<MembershipApplication>> FindExpiredApplications();
     Task<MembershipApplication?> FindPendingBy(CapabilityId capabilityId, UserId userId);
     Task<MembershipApplication?> FindBy(MembershipApplicationId id);

--- a/src/SelfService/Domain/Services/AuthorizationService.cs
+++ b/src/SelfService/Domain/Services/AuthorizationService.cs
@@ -238,11 +238,15 @@ public class AuthorizationService : IAuthorizationService
         return IsCloudEngineerEnabled(portalUser);
     }
 
-    public async Task<bool> CanDeleteMembershipApplication(PortalUser portalUser, UserId userId, MembershipApplicationId membershipApplicationId)
+    public async Task<bool> CanDeleteMembershipApplication(
+        PortalUser portalUser,
+        UserId userId,
+        MembershipApplicationId membershipApplicationId
+    )
     {
         var membershipApp = await _membershipApplicationRepository.Get(membershipApplicationId);
         var hasMembership = await _membershipQuery.HasActiveMembership(userId, membershipApp.CapabilityId);
-        
+
         return hasMembership || IsCloudEngineerEnabled(portalUser);
     }
 

--- a/src/SelfService/Domain/Services/IAuthorizationService.cs
+++ b/src/SelfService/Domain/Services/IAuthorizationService.cs
@@ -31,7 +31,7 @@ public interface IAuthorizationService
     bool CanSynchronizeAwsECRAndDatabaseECR(PortalUser portalUser);
     Task<bool> CanGetSetCapabilityJsonMetadata(PortalUser portalUser, CapabilityId capabilityId);
     bool CanBypassMembershipApprovals(PortalUser portalUser);
-    bool CanDeleteMembershipApplications(PortalUser portalUser);
+    Task<bool> CanDeleteMembershipApplication(PortalUser portalUser, UserId userId, MembershipApplicationId membershipApplicationId);
     Task<bool> CanInviteToCapability(UserId userId, CapabilityId capabilityId);
     Task<bool> CanSeeAwsAccountId(PortalUser portalUser, CapabilityId capabilityId);
     Task<bool> CanRetryCreatingMessageContract(PortalUser portalUser, MessageContractId messageContractId);

--- a/src/SelfService/Domain/Services/IAuthorizationService.cs
+++ b/src/SelfService/Domain/Services/IAuthorizationService.cs
@@ -31,7 +31,11 @@ public interface IAuthorizationService
     bool CanSynchronizeAwsECRAndDatabaseECR(PortalUser portalUser);
     Task<bool> CanGetSetCapabilityJsonMetadata(PortalUser portalUser, CapabilityId capabilityId);
     bool CanBypassMembershipApprovals(PortalUser portalUser);
-    Task<bool> CanDeleteMembershipApplication(PortalUser portalUser, UserId userId, MembershipApplicationId membershipApplicationId);
+    Task<bool> CanDeleteMembershipApplication(
+        PortalUser portalUser,
+        UserId userId,
+        MembershipApplicationId membershipApplicationId
+    );
     Task<bool> CanInviteToCapability(UserId userId, CapabilityId capabilityId);
     Task<bool> CanSeeAwsAccountId(PortalUser portalUser, CapabilityId capabilityId);
     Task<bool> CanRetryCreatingMessageContract(PortalUser portalUser, MessageContractId messageContractId);

--- a/src/SelfService/Infrastructure/Api/ApiResourceFactory.cs
+++ b/src/SelfService/Infrastructure/Api/ApiResourceFactory.cs
@@ -959,8 +959,11 @@ public class ApiResourceFactory
             )
         );
     }
-    
-    public MembershipApplicationThatUserCanApproveApiResource ConvertToMembershipApplicationThatUserCanApproveApiResource(MembershipApplication application, UserId currentUser)
+
+    public MembershipApplicationThatUserCanApproveApiResource ConvertToMembershipApplicationThatUserCanApproveApiResource(
+        MembershipApplication application,
+        UserId currentUser
+    )
     {
         var isCurrentUserTheApplicant = application.Applicant == currentUser;
 
@@ -1135,10 +1138,17 @@ public class ApiResourceFactory
         return resource;
     }
 
-    public Task<MembershipApplicationThatUserCanApproveListApiResource> Convert(IEnumerable<MembershipApplication> applications, UserId currentUser)
+    public Task<MembershipApplicationThatUserCanApproveListApiResource> Convert(
+        IEnumerable<MembershipApplication> applications,
+        UserId currentUser
+    )
     {
         var resource = new MembershipApplicationThatUserCanApproveListApiResource(
-            items: applications.Select(application => ConvertToMembershipApplicationThatUserCanApproveApiResource(application, currentUser)).ToArray(),
+            items: applications
+                .Select(
+                    application => ConvertToMembershipApplicationThatUserCanApproveApiResource(application, currentUser)
+                )
+                .ToArray(),
             links: new MembershipApplicationThatUserCanApproveListApiResource.MembershipApplicationListLinks(
                 self: new ResourceLink(
                     href: _linkGenerator.GetUriByAction(
@@ -1151,7 +1161,7 @@ public class ApiResourceFactory
                 )
             )
         );
-        
+
         return Task.FromResult(resource);
     }
 

--- a/src/SelfService/Infrastructure/Api/Capabilities/MembershipApplicationThatUserCanApproveApiResource.cs
+++ b/src/SelfService/Infrastructure/Api/Capabilities/MembershipApplicationThatUserCanApproveApiResource.cs
@@ -14,7 +14,8 @@ public class MembershipApplicationThatUserCanApproveApiResource : MembershipAppl
         string expiresOn,
         MembershipApprovalListApiResource approvals,
         MembershipApplicationLinks links
-    ) : base(id, applicant, submittedAt, expiresOn, approvals, links)
+    )
+        : base(id, applicant, submittedAt, expiresOn, approvals, links)
     {
         CapabilityId = capabilityId;
     }

--- a/src/SelfService/Infrastructure/Api/Capabilities/MembershipApplicationThatUserCanApproveApiResource.cs
+++ b/src/SelfService/Infrastructure/Api/Capabilities/MembershipApplicationThatUserCanApproveApiResource.cs
@@ -1,0 +1,21 @@
+﻿using System.Text.Json.Serialization;
+
+namespace SelfService.Infrastructure.Api.Capabilities;
+
+public class MembershipApplicationThatUserCanApproveApiResource : MembershipApplicationApiResource
+{
+    public string CapabilityId { get; set; }
+
+    public MembershipApplicationThatUserCanApproveApiResource(
+        string id,
+        string capabilityId,
+        string applicant,
+        string submittedAt,
+        string expiresOn,
+        MembershipApprovalListApiResource approvals,
+        MembershipApplicationLinks links
+    ) : base(id, applicant, submittedAt, expiresOn, approvals, links)
+    {
+        CapabilityId = capabilityId;
+    }
+}

--- a/src/SelfService/Infrastructure/Api/Capabilities/MembershipApplicationThatUserCanApproveListApiResource.cs
+++ b/src/SelfService/Infrastructure/Api/Capabilities/MembershipApplicationThatUserCanApproveListApiResource.cs
@@ -1,0 +1,30 @@
+﻿using System.Text.Json.Serialization;
+
+namespace SelfService.Infrastructure.Api.Capabilities;
+
+public class MembershipApplicationThatUserCanApproveListApiResource
+{
+    public MembershipApplicationThatUserCanApproveApiResource[] Items { get; set; }
+
+    [JsonPropertyName("_links")]
+    public MembershipApplicationListLinks Links { get; set; }
+
+    public class MembershipApplicationListLinks
+    {
+        public ResourceLink Self { get; set; }
+
+        public MembershipApplicationListLinks(ResourceLink self)
+        {
+            Self = self;
+        }
+    }
+
+    public MembershipApplicationThatUserCanApproveListApiResource(
+        MembershipApplicationThatUserCanApproveApiResource[] items,
+        MembershipApplicationListLinks links
+    )
+    {
+        Items = items;
+        Links = links;
+    }
+}

--- a/src/SelfService/Infrastructure/Api/MembershipApplications/MembershipApplicationController.cs
+++ b/src/SelfService/Infrastructure/Api/MembershipApplications/MembershipApplicationController.cs
@@ -146,7 +146,7 @@ public class MembershipApplicationController : ControllerBase
                 }
             );
         }
-        
+
         if (!MembershipApplicationId.TryParse(id, out var membershipApplicationId))
         {
             return NotFound(
@@ -159,7 +159,7 @@ public class MembershipApplicationController : ControllerBase
         }
 
         var portalUser = HttpContext.User.ToPortalUser();
-        if (! await _authorizationService.CanDeleteMembershipApplication(portalUser, userId, membershipApplicationId))
+        if (!await _authorizationService.CanDeleteMembershipApplication(portalUser, userId, membershipApplicationId))
         {
             return Unauthorized(
                 new ProblemDetails

--- a/src/SelfService/Infrastructure/Api/MembershipApplications/MembershipApplicationController.cs
+++ b/src/SelfService/Infrastructure/Api/MembershipApplications/MembershipApplicationController.cs
@@ -230,7 +230,7 @@ public class MembershipApplicationController : ControllerBase
         }
     }
 
-    [HttpGet("me")]
+    [HttpGet("eligible-for-approval")]
     [ProducesResponseType(typeof(MembershipApplicationListApiResource), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized, "application/problem+json")]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound, "application/problem+json")]

--- a/src/SelfService/Infrastructure/Api/MembershipApplications/MembershipApplicationController.cs
+++ b/src/SelfService/Infrastructure/Api/MembershipApplications/MembershipApplicationController.cs
@@ -146,19 +146,7 @@ public class MembershipApplicationController : ControllerBase
                 }
             );
         }
-
-        var portalUser = HttpContext.User.ToPortalUser();
-        if (!_authorizationService.CanDeleteMembershipApplications(portalUser))
-        {
-            return Unauthorized(
-                new ProblemDetails
-                {
-                    Title = "User unauthorized",
-                    Detail = $"user \"{userId}\" isn't authorized to delete membership applications."
-                }
-            );
-        }
-
+        
         if (!MembershipApplicationId.TryParse(id, out var membershipApplicationId))
         {
             return NotFound(
@@ -166,6 +154,18 @@ public class MembershipApplicationController : ControllerBase
                 {
                     Title = "Membership application not found.",
                     Detail = $"A membership application with id \"{id}\" could not be found."
+                }
+            );
+        }
+
+        var portalUser = HttpContext.User.ToPortalUser();
+        if (! await _authorizationService.CanDeleteMembershipApplication(portalUser, userId, membershipApplicationId))
+        {
+            return Unauthorized(
+                new ProblemDetails
+                {
+                    Title = "User unauthorized",
+                    Detail = $"user \"{userId}\" isn't authorized to delete membership applications."
                 }
             );
         }
@@ -228,5 +228,26 @@ public class MembershipApplicationController : ControllerBase
                 }
             );
         }
+    }
+
+    [HttpGet("me")]
+    [ProducesResponseType(typeof(MembershipApplicationListApiResource), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized, "application/problem+json")]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound, "application/problem+json")]
+    public async Task<IActionResult> MembershipsThatUserCanApprove()
+    {
+        if (!User.TryGetUserId(out var userId))
+        {
+            return Unauthorized(
+                new ProblemDetails
+                {
+                    Title = "Unknown user id",
+                    Detail = $"User id is not valid and cannot be used to approve a membership application.",
+                }
+            );
+        }
+        var result = await _membershipApplicationService.GetMembershipsApplicationsThatUserCanApprove(userId);
+
+        return Ok(await _apiResourceFactory.Convert(result, userId));
     }
 }

--- a/src/SelfService/Infrastructure/Persistence/MembershipApplicationRepository.cs
+++ b/src/SelfService/Infrastructure/Persistence/MembershipApplicationRepository.cs
@@ -35,6 +35,12 @@ public class MembershipApplicationRepository : IMembershipApplicationRepository
         return result;
     }
 
+    public async Task<IEnumerable<MembershipApplication>> GetAll()
+    {
+        var result = await _dbContext.MembershipApplications.ToListAsync();
+        return result;
+    }
+
     public async Task<MembershipApplication?> FindBy(MembershipApplicationId id)
     {
         return await _dbContext.MembershipApplications.Include(x => x.Approvals).FirstOrDefaultAsync(x => x.Id == id);


### PR DESCRIPTION
Issue: https://github.com/dfds/cloudplatform/issues/2929

- Added API endpoint for getting membership requests that the current user can approve or decline
- Updated API endpoint to allow members of Capability to reject membership application
