### PR TITLE
wip: add confluent schemas via confluent gateway api

### DIFF
--- a/db/seed/KafkaCluster.csv
+++ b/db/seed/KafkaCluster.csv
@@ -1,3 +1,3 @@
 Id;Name;Description;Enabled;BootstrapServers;SchemaRegistryUrl
-dev1;Development;A development cluster special for you;1;localhost:9092;localhost
-prod1;Production;This is production;1;localhost:9092;localhost
+abc-1234;Development;A development cluster special for you;1;localhost:9092;localhost
+def-5678;Production;This is production;1;localhost:9092;localhost

--- a/db/seed/KafkaClusterAccess.csv
+++ b/db/seed/KafkaClusterAccess.csv
@@ -1,3 +1,3 @@
 Id;CapabilityId;KafkaClusterId;CreatedBy;CreatedAt;GrantedAt
-4516ef0f-152f-4f26-84cf-0625110f6c8b;cloudengineering-xxx;prod1;SYSTEM;2023-05-28T:16:36:00;2023-05-28T:16:37:00
-fc0e53d0-24eb-4ac9-9235-2bd08de5c9df;marketing-department-xxx;prod1;SYSTEM;2023-05-28T:16:36:00;2023-05-28T:16:37:00
+4516ef0f-152f-4f26-84cf-0625110f6c8b;cloudengineering-xxx;abc-1234;SYSTEM;2023-05-28T:16:36:00;2023-05-28T:16:37:00
+fc0e53d0-24eb-4ac9-9235-2bd08de5c9df;marketing-department-xxx;abc-1234;SYSTEM;2023-05-28T:16:36:00;2023-05-28T:16:37:00

--- a/db/seed/KafkaTopic.csv
+++ b/db/seed/KafkaTopic.csv
@@ -1,5 +1,6 @@
 Id;CapabilityId;KafkaClusterId;Name;Description;Partitions;Status;CreatedAt;CreatedBy;ModifiedAt;ModifiedBy;Retention
 C670D5DC-89A9-4354-9403-4A1E03D66DA5;cloudengineering-xxx;abc-1234;cloudengineering-xxx.this-is-a-private-topic;For all the private foos;3;Provisioned;2023-02-10T08:00:00;SeedScript;2023-02-10T08:00:00;SeedScript;1d
 269C3064-E1AD-49A8-8FE8-781E04A51303;cloudengineering-xxx;abc-1234;pub.cloudengineering-xxx.this-is-real;Public stuff;3;Provisioned;2023-02-10T08:00:00;SeedScript;2023-03-11T08:00:00;SeedScript;1d
+269C3064-E1AD-49A8-8FE8-781E04A51304;cloudengineering-xxx;abc-1234;cloudengineering.selfservice.test;Public stuff;3;Provisioned;2024-02-10T08:00:00;SeedScript;2024-03-11T08:00:00;SeedScript;1d
 8DB0C6D4-C9AC-41E4-8E17-D5EEFCB5F4D3;marketing-department-xxx;abc-1234;marketing-department-xxx.this-is-a-private-topic;For all the private foos;3;Provisioned;2023-02-10T08:00:00;SeedScript;2023-02-10T08:00:00;SeedScript;1d
 6ACC6871-7AAF-4E57-8136-9ED076903806;marketing-department-xxx;abc-1234;pub.marketing-department-xxx.hello-world;Public stuff;3;Provisioned;2023-02-10T08:00:00;SeedScript;2023-03-11T08:00:00;SeedScript;1d

--- a/db/seed/KafkaTopic.csv
+++ b/db/seed/KafkaTopic.csv
@@ -1,5 +1,5 @@
 Id;CapabilityId;KafkaClusterId;Name;Description;Partitions;Status;CreatedAt;CreatedBy;ModifiedAt;ModifiedBy;Retention
-C670D5DC-89A9-4354-9403-4A1E03D66DA5;cloudengineering-xxx;prod1;cloudengineering-xxx.this-is-a-private-topic;For all the private foos;3;Provisioned;2023-02-10T08:00:00;SeedScript;2023-02-10T08:00:00;SeedScript;1d
-269C3064-E1AD-49A8-8FE8-781E04A51303;cloudengineering-xxx;prod1;pub.cloudengineering-xxx.this-is-real;Public stuff;3;Provisioned;2023-02-10T08:00:00;SeedScript;2023-03-11T08:00:00;SeedScript;1d
-8DB0C6D4-C9AC-41E4-8E17-D5EEFCB5F4D3;marketing-department-xxx;prod1;marketing-department-xxx.this-is-a-private-topic;For all the private foos;3;Provisioned;2023-02-10T08:00:00;SeedScript;2023-02-10T08:00:00;SeedScript;1d
-6ACC6871-7AAF-4E57-8136-9ED076903806;marketing-department-xxx;prod1;pub.marketing-department-xxx.hello-world;Public stuff;3;Provisioned;2023-02-10T08:00:00;SeedScript;2023-03-11T08:00:00;SeedScript;1d
+C670D5DC-89A9-4354-9403-4A1E03D66DA5;cloudengineering-xxx;abc-1234;cloudengineering-xxx.this-is-a-private-topic;For all the private foos;3;Provisioned;2023-02-10T08:00:00;SeedScript;2023-02-10T08:00:00;SeedScript;1d
+269C3064-E1AD-49A8-8FE8-781E04A51303;cloudengineering-xxx;abc-1234;pub.cloudengineering-xxx.this-is-real;Public stuff;3;Provisioned;2023-02-10T08:00:00;SeedScript;2023-03-11T08:00:00;SeedScript;1d
+8DB0C6D4-C9AC-41E4-8E17-D5EEFCB5F4D3;marketing-department-xxx;abc-1234;marketing-department-xxx.this-is-a-private-topic;For all the private foos;3;Provisioned;2023-02-10T08:00:00;SeedScript;2023-02-10T08:00:00;SeedScript;1d
+6ACC6871-7AAF-4E57-8136-9ED076903806;marketing-department-xxx;abc-1234;pub.marketing-department-xxx.hello-world;Public stuff;3;Provisioned;2023-02-10T08:00:00;SeedScript;2023-03-11T08:00:00;SeedScript;1d

--- a/src/SelfService.Tests/Builders/CapabilityApplicationServiceBuilder.cs
+++ b/src/SelfService.Tests/Builders/CapabilityApplicationServiceBuilder.cs
@@ -54,7 +54,8 @@ public class CapabilityApplicationServiceBuilder
             ticketingSystem: Mock.Of<ITicketingSystem>(),
             systemTime: SystemTime.Default,
             selfServiceJsonSchemaService: _selfServiceJsonSchemaService,
-            configurationLevelService: _configurationLevelService
+            configurationLevelService: _configurationLevelService,
+            confluentGatewayService: Mock.Of<IConfluentGatewayService>()
         );
     }
 

--- a/src/SelfService.Tests/Infrastructure/Api/ApiApplication.cs
+++ b/src/SelfService.Tests/Infrastructure/Api/ApiApplication.cs
@@ -95,6 +95,7 @@ public class ApiApplication : WebApplicationFactory<Program>
         builder.UseSetting("SS_PROMETHEUS_API_ENDPOINT", "http://localhost:9090");
         builder.UseSetting("SS_PLATFORM_DATA_ENDPOINT", "http://localhost:8070");
         builder.UseSetting("SS_PLATFORM_DATA_API_KEY", "dummykey");
+        builder.UseSetting("SS_CONFLUENT_GATEWAY_API_ENDPOINT", "http://localhost:8080");
 
         builder.ConfigureAppConfiguration(x =>
         {

--- a/src/SelfService/Application/CapabilityApplicationService.cs
+++ b/src/SelfService/Application/CapabilityApplicationService.cs
@@ -20,6 +20,8 @@ public class CapabilityApplicationService : ICapabilityApplicationService
     private readonly ISelfServiceJsonSchemaService _selfServiceJsonSchemaService;
     private readonly IConfigurationLevelService _configurationLevelService;
 
+    private readonly IConfluentGatewayService _confluentGatewayService;
+
     private const int PendingDaysUntilDeletion = 7;
 
     public CapabilityApplicationService(
@@ -31,7 +33,8 @@ public class CapabilityApplicationService : ICapabilityApplicationService
         ITicketingSystem ticketingSystem,
         SystemTime systemTime,
         ISelfServiceJsonSchemaService selfServiceJsonSchemaService,
-        IConfigurationLevelService configurationLevelService
+        IConfigurationLevelService configurationLevelService,
+        IConfluentGatewayService confluentGatewayService
     )
     {
         _logger = logger;
@@ -43,6 +46,7 @@ public class CapabilityApplicationService : ICapabilityApplicationService
         _systemTime = systemTime;
         _selfServiceJsonSchemaService = selfServiceJsonSchemaService;
         _configurationLevelService = configurationLevelService;
+        _confluentGatewayService = confluentGatewayService;
     }
 
     [TransactionalBoundary, Outboxed]

--- a/src/SelfService/Application/IKafkaSchemaService.cs
+++ b/src/SelfService/Application/IKafkaSchemaService.cs
@@ -1,0 +1,11 @@
+using System;
+using SelfService.Domain.Models;
+using SelfService.Domain.Queries;
+
+namespace SelfService.Application;
+
+public interface IKafkaSchemaService
+{
+    public Task<List<KafkaSchema>> ListSchemas(KafkaSchemaQueryParams queryParams);
+
+}

--- a/src/SelfService/Application/IKafkaSchemaService.cs
+++ b/src/SelfService/Application/IKafkaSchemaService.cs
@@ -6,6 +6,5 @@ namespace SelfService.Application;
 
 public interface IKafkaSchemaService
 {
-    public Task<List<KafkaSchema>> ListSchemas(KafkaSchemaQueryParams queryParams);
-
+    public Task<List<KafkaSchema>> ListSchemas(string clusterId, KafkaSchemaQueryParams queryParams);
 }

--- a/src/SelfService/Application/KafkaSchemaService.cs
+++ b/src/SelfService/Application/KafkaSchemaService.cs
@@ -1,0 +1,29 @@
+using System;
+using SelfService.Domain.Models;
+using SelfService.Domain.Queries;
+using SelfService.Domain.Services;
+using SelfService.Infrastructure.Kafka;
+
+namespace SelfService.Application;
+
+public class KafkaSchemaService : IKafkaSchemaService
+{
+    private readonly IConfluentGatewayService _confluentGatewayClient;
+
+    public KafkaSchemaService(IConfluentGatewayService confluentGatewayClient)
+    {
+        _confluentGatewayClient = confluentGatewayClient;
+    }
+
+    public async Task<List<KafkaSchema>> ListSchemas(KafkaSchemaQueryParams queryParams)
+    {
+        try
+        {
+            return await _confluentGatewayClient.ListSchemas(queryParams);
+        }
+        catch (Exception ex)
+        {
+            throw new Exception("Failed to list schemas", ex);
+        }
+    }
+}

--- a/src/SelfService/Application/KafkaSchemaService.cs
+++ b/src/SelfService/Application/KafkaSchemaService.cs
@@ -15,11 +15,11 @@ public class KafkaSchemaService : IKafkaSchemaService
         _confluentGatewayClient = confluentGatewayClient;
     }
 
-    public async Task<List<KafkaSchema>> ListSchemas(KafkaSchemaQueryParams queryParams)
+    public async Task<List<KafkaSchema>> ListSchemas(string clusterId, KafkaSchemaQueryParams queryParams)
     {
         try
         {
-            return await _confluentGatewayClient.ListSchemas(queryParams);
+            return await _confluentGatewayClient.ListSchemas(clusterId, queryParams);
         }
         catch (Exception ex)
         {

--- a/src/SelfService/Configuration/Domain.cs
+++ b/src/SelfService/Configuration/Domain.cs
@@ -10,6 +10,7 @@ using SelfService.Infrastructure.Persistence.Queries;
 using SelfService.Infrastructure.Ticketing;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using SelfService.Infrastructure.Api.Prometheus;
+using SelfService.Infrastructure.Kafka;
 
 namespace SelfService.Configuration;
 
@@ -32,6 +33,7 @@ public static class Domain
         builder.Services.AddTransient<IPortalVisitApplicationService, PortalVisitApplicationService>();
         builder.Services.AddTransient<ITeamApplicationService, TeamApplicationService>();
         builder.Services.AddTransient<IInvitationApplicationService, InvitationApplicationService>();
+        builder.Services.AddTransient<IKafkaSchemaService, KafkaSchemaService>();
 
         if (aws_type == "mock")
         {
@@ -145,6 +147,12 @@ public static class Domain
         {
             client.BaseAddress = platformDataEndpoint;
             client.DefaultRequestHeaders.Add("x-api-key", dataApiKey);
+        });
+
+        var confluentGatewayApiEndpoint = new Uri(builder.Configuration["SS_CONFLUENT_GATEWAY_API_ENDPOINT"] ?? "");
+        builder.Services.AddHttpClient<IConfluentGatewayService, ConfluentGateway>(client =>
+        {
+            client.BaseAddress = confluentGatewayApiEndpoint;
         });
     }
 }

--- a/src/SelfService/Configuration/Domain.cs
+++ b/src/SelfService/Configuration/Domain.cs
@@ -150,7 +150,7 @@ public static class Domain
         });
 
         var confluentGatewayApiEndpoint = new Uri(builder.Configuration["SS_CONFLUENT_GATEWAY_API_ENDPOINT"] ?? "");
-        builder.Services.AddHttpClient<IConfluentGatewayService, ConfluentGateway>(client =>
+        builder.Services.AddHttpClient<IConfluentGatewayService, ConfluentGatewayService>(client =>
         {
             client.BaseAddress = confluentGatewayApiEndpoint;
         });

--- a/src/SelfService/Domain/Models/KafkaSchema.cs
+++ b/src/SelfService/Domain/Models/KafkaSchema.cs
@@ -10,7 +10,7 @@ public class KafkaSchema
         int id,
         string schemaType,
         List<KafkaSchemaReference> references,
-        string schemaContent,
+        string schema,
         KafkaSchemaMetadata metadata,
         KafkaSchemaRuleSet ruleSet
     )
@@ -20,17 +20,17 @@ public class KafkaSchema
         ID = id;
         SchemaType = schemaType;
         References = references;
-        SchemaContent = schemaContent;
+        Schema = schema;
         Metadata = metadata;
         RuleSet = ruleSet;
     }
+
     public string Subject { get; set; }
     public int Version { get; set; }
     public int ID { get; set; }
     public string SchemaType { get; set; }
     public List<KafkaSchemaReference> References { get; set; }
-    public string SchemaContent { get; set; }
+    public string Schema { get; set; }
     public KafkaSchemaMetadata Metadata { get; set; }
     public KafkaSchemaRuleSet RuleSet { get; set; }
-
 }

--- a/src/SelfService/Domain/Models/KafkaSchema.cs
+++ b/src/SelfService/Domain/Models/KafkaSchema.cs
@@ -1,0 +1,36 @@
+using System;
+
+namespace SelfService.Domain.Models;
+
+public class KafkaSchema
+{
+    public KafkaSchema(
+        string subject,
+        int version,
+        int id,
+        string schemaType,
+        List<KafkaSchemaReference> references,
+        string schemaContent,
+        KafkaSchemaMetadata metadata,
+        KafkaSchemaRuleSet ruleSet
+    )
+    {
+        Subject = subject;
+        Version = version;
+        ID = id;
+        SchemaType = schemaType;
+        References = references;
+        SchemaContent = schemaContent;
+        Metadata = metadata;
+        RuleSet = ruleSet;
+    }
+    public string Subject { get; set; }
+    public int Version { get; set; }
+    public int ID { get; set; }
+    public string SchemaType { get; set; }
+    public List<KafkaSchemaReference> References { get; set; }
+    public string SchemaContent { get; set; }
+    public KafkaSchemaMetadata Metadata { get; set; }
+    public KafkaSchemaRuleSet RuleSet { get; set; }
+
+}

--- a/src/SelfService/Domain/Models/KafkaSchemaMetadata.cs
+++ b/src/SelfService/Domain/Models/KafkaSchemaMetadata.cs
@@ -17,5 +17,5 @@ public class KafkaSchemaMetadata
 
     public Dictionary<string, List<string>> Tags { get; set; }
     public Dictionary<string, string> Properties { get; set; }
-    public List<string> Sensitive { get; set; }   
+    public List<string> Sensitive { get; set; }
 }

--- a/src/SelfService/Domain/Models/KafkaSchemaMetadata.cs
+++ b/src/SelfService/Domain/Models/KafkaSchemaMetadata.cs
@@ -1,0 +1,21 @@
+using System;
+
+namespace SelfService.Domain.Models;
+
+public class KafkaSchemaMetadata
+{
+    public KafkaSchemaMetadata(
+        Dictionary<string, List<string>> tags,
+        Dictionary<string, string> properties,
+        List<string> sensitive
+    )
+    {
+        Tags = tags;
+        Properties = properties;
+        Sensitive = sensitive;
+    }
+
+    public Dictionary<string, List<string>> Tags { get; set; }
+    public Dictionary<string, string> Properties { get; set; }
+    public List<string> Sensitive { get; set; }   
+}

--- a/src/SelfService/Domain/Models/KafkaSchemaParams.cs
+++ b/src/SelfService/Domain/Models/KafkaSchemaParams.cs
@@ -1,0 +1,18 @@
+using System;
+
+namespace SelfService.Domain.Models;
+
+public class KafkaSchemaParams
+{
+    public KafkaSchemaParams(
+        string property1, 
+        string property2
+    )
+    {
+        Property1 = property1;
+        Property2 = property2;
+    }
+
+    public string Property1 { get; set; }
+    public string Property2 { get; set; }
+}

--- a/src/SelfService/Domain/Models/KafkaSchemaParams.cs
+++ b/src/SelfService/Domain/Models/KafkaSchemaParams.cs
@@ -4,10 +4,7 @@ namespace SelfService.Domain.Models;
 
 public class KafkaSchemaParams
 {
-    public KafkaSchemaParams(
-        string property1, 
-        string property2
-    )
+    public KafkaSchemaParams(string property1, string property2)
     {
         Property1 = property1;
         Property2 = property2;

--- a/src/SelfService/Domain/Models/KafkaSchemaReference.cs
+++ b/src/SelfService/Domain/Models/KafkaSchemaReference.cs
@@ -4,11 +4,7 @@ namespace SelfService.Domain.Models;
 
 public class KafkaSchemaReference
 {
-    public KafkaSchemaReference(
-        string name, 
-        string subject, 
-        int version
-    )
+    public KafkaSchemaReference(string name, string subject, int version)
     {
         Name = name;
         Subject = subject;
@@ -18,5 +14,4 @@ public class KafkaSchemaReference
     public string Name { get; set; }
     public string Subject { get; set; }
     public int Version { get; set; }
-
 }

--- a/src/SelfService/Domain/Models/KafkaSchemaReference.cs
+++ b/src/SelfService/Domain/Models/KafkaSchemaReference.cs
@@ -1,0 +1,22 @@
+using System;
+
+namespace SelfService.Domain.Models;
+
+public class KafkaSchemaReference
+{
+    public KafkaSchemaReference(
+        string name, 
+        string subject, 
+        int version
+    )
+    {
+        Name = name;
+        Subject = subject;
+        Version = version;
+    }
+
+    public string Name { get; set; }
+    public string Subject { get; set; }
+    public int Version { get; set; }
+
+}

--- a/src/SelfService/Domain/Models/KafkaSchemaRule.cs
+++ b/src/SelfService/Domain/Models/KafkaSchemaRule.cs
@@ -1,0 +1,45 @@
+using System;
+
+namespace SelfService.Domain.Models;
+
+public class KafkaSchemaRule
+{
+    public KafkaSchemaRule(
+        string name,
+        string doc,
+        string kind,
+        string mode,
+        string type,
+        List<string> tags,
+        KafkaSchemaParams parameters,
+        string expr,
+        string onSuccess,
+        string onFailure,
+        bool disabled
+    )
+    {
+        Name = name;
+        Doc = doc;
+        Kind = kind;
+        Mode = mode;
+        Type = type;
+        Tags = tags;
+        Params = parameters;
+        Expr = expr;
+        OnSuccess = onSuccess;
+        OnFailure = onFailure;
+        Disabled = disabled;
+    }
+
+    public string Name { get; set; }
+    public string Doc { get; set; }
+    public string Kind { get; set; }
+    public string Mode { get; set; }
+    public string Type { get; set; }
+    public List<string> Tags { get; set; }
+    public KafkaSchemaParams Params { get; set; }
+    public string Expr { get; set; }
+    public string OnSuccess { get; set; }
+    public string OnFailure { get; set; }
+    public bool Disabled { get; set; }
+}

--- a/src/SelfService/Domain/Models/KafkaSchemaRuleSet.cs
+++ b/src/SelfService/Domain/Models/KafkaSchemaRuleSet.cs
@@ -4,10 +4,7 @@ namespace SelfService.Domain.Models;
 
 public class KafkaSchemaRuleSet
 {
-    public KafkaSchemaRuleSet(
-        List<KafkaSchemaRule> migrationRules,
-        List<KafkaSchemaRule> domainRules
-    )
+    public KafkaSchemaRuleSet(List<KafkaSchemaRule> migrationRules, List<KafkaSchemaRule> domainRules)
     {
         MigrationRules = migrationRules;
         DomainRules = domainRules;
@@ -15,5 +12,4 @@ public class KafkaSchemaRuleSet
 
     public List<KafkaSchemaRule> MigrationRules { get; set; }
     public List<KafkaSchemaRule> DomainRules { get; set; }
-
 }

--- a/src/SelfService/Domain/Models/KafkaSchemaRuleSet.cs
+++ b/src/SelfService/Domain/Models/KafkaSchemaRuleSet.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace SelfService.Domain.Models;
+
+public class KafkaSchemaRuleSet
+{
+    public KafkaSchemaRuleSet(
+        List<KafkaSchemaRule> migrationRules,
+        List<KafkaSchemaRule> domainRules
+    )
+    {
+        MigrationRules = migrationRules;
+        DomainRules = domainRules;
+    }
+
+    public List<KafkaSchemaRule> MigrationRules { get; set; }
+    public List<KafkaSchemaRule> DomainRules { get; set; }
+
+}

--- a/src/SelfService/Domain/Queries/IKafkaSchemaQuery.cs
+++ b/src/SelfService/Domain/Queries/IKafkaSchemaQuery.cs
@@ -1,0 +1,14 @@
+using System;
+using SelfService.Domain.Models;
+
+namespace SelfService.Domain.Queries;
+
+public interface IKafkaSchemaQuery
+{
+    Task<List<KafkaSchema>> ListSchemas();
+}
+
+public class KafkaSchemaQueryParams
+{
+    public string? SubjectPrefix { get; set; }
+}

--- a/src/SelfService/Domain/Services/IConfluentGatewayService.cs
+++ b/src/SelfService/Domain/Services/IConfluentGatewayService.cs
@@ -6,5 +6,5 @@ namespace SelfService.Domain.Services;
 
 public interface IConfluentGatewayService
 {
-    public Task<List<KafkaSchema>> ListSchemas(KafkaSchemaQueryParams queryParams);
+    public Task<List<KafkaSchema>> ListSchemas(string clusterId, KafkaSchemaQueryParams queryParams);
 }

--- a/src/SelfService/Domain/Services/IConfluentGatewayService.cs
+++ b/src/SelfService/Domain/Services/IConfluentGatewayService.cs
@@ -1,0 +1,10 @@
+using System;
+using SelfService.Domain.Models;
+using SelfService.Domain.Queries;
+
+namespace SelfService.Domain.Services;
+
+public interface IConfluentGatewayService
+{
+    public Task<List<KafkaSchema>> ListSchemas(KafkaSchemaQueryParams queryParams);
+}

--- a/src/SelfService/Infrastructure/Api/ApiResourceFactory.cs
+++ b/src/SelfService/Infrastructure/Api/ApiResourceFactory.cs
@@ -1158,6 +1158,16 @@ public class ApiResourceFactory
                             rel: "related",
                             allow: Allow.Get
                         ),
+                        schemas: new ResourceLink(
+                            href: _linkGenerator.GetUriByAction(
+                                httpContext: HttpContext,
+                                action: nameof(KafkaSchemaController.ListSchemas),
+                                controller: GetNameOf<KafkaSchemaController>()
+                                // values: new { capabilityId, clusterId = cluster.Id }
+                            ) ?? "",
+                            rel: "related",
+                            allow: Allow.Get
+                        ),
                         requestAccess: new ResourceLink(
                             href: _linkGenerator.GetUriByAction(
                                 httpContext: HttpContext,

--- a/src/SelfService/Infrastructure/Api/ApiResourceFactory.cs
+++ b/src/SelfService/Infrastructure/Api/ApiResourceFactory.cs
@@ -1162,8 +1162,8 @@ public class ApiResourceFactory
                             href: _linkGenerator.GetUriByAction(
                                 httpContext: HttpContext,
                                 action: nameof(KafkaSchemaController.ListSchemas),
-                                controller: GetNameOf<KafkaSchemaController>()
-                                // values: new { capabilityId, clusterId = cluster.Id }
+                                controller: GetNameOf<KafkaSchemaController>(),
+                                values: new { subjectPrefix = capabilityId, clusterId = cluster.Id }
                             ) ?? "",
                             rel: "related",
                             allow: Allow.Get

--- a/src/SelfService/Infrastructure/Api/Capabilities/KafkaClusterAccessListApiResource.cs
+++ b/src/SelfService/Infrastructure/Api/Capabilities/KafkaClusterAccessListApiResource.cs
@@ -41,6 +41,7 @@ public class KafkaClusterAccessListItemApiResource
     public class KafkaClusterAccessListItem
     {
         public ResourceLink Topics { get; set; }
+        public ResourceLink Schemas { get; set; }
         public ResourceLink Access { get; set; }
         public ResourceLink RequestAccess { get; set; }
         public ResourceLink CreateTopic { get; set; }
@@ -49,11 +50,13 @@ public class KafkaClusterAccessListItemApiResource
             ResourceLink topics,
             ResourceLink access,
             ResourceLink requestAccess,
+            ResourceLink schemas,
             ResourceLink createTopic
         )
         {
             Topics = topics;
             Access = access;
+            Schemas = schemas;
             RequestAccess = requestAccess;
             CreateTopic = createTopic;
         }

--- a/src/SelfService/Infrastructure/Api/Kafka/KafkaSchemaController.cs
+++ b/src/SelfService/Infrastructure/Api/Kafka/KafkaSchemaController.cs
@@ -12,24 +12,21 @@ public class KafkaSchemaController : ControllerBase
     private readonly ILogger<KafkaSchemaController> _logger;
     private readonly IKafkaSchemaService _kafkaSchemaService;
 
-    public KafkaSchemaController(
-        ILogger<KafkaSchemaController> logger,
-        IKafkaSchemaService kafkaSchemaService
-    )
+    public KafkaSchemaController(ILogger<KafkaSchemaController> logger, IKafkaSchemaService kafkaSchemaService)
     {
         _logger = logger;
         _kafkaSchemaService = kafkaSchemaService;
     }
 
-    [HttpGet("")]
+    [HttpGet("{clusterId:required}")]
     [ProducesResponseType(typeof(KafkaSchema[]), StatusCodes.Status200OK, "application/json")]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized, "application/problem+json")]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status500InternalServerError, "application/problem+json")]
-    public async Task<IActionResult> ListSchemas([FromQuery] KafkaSchemaQueryParams queryParams)
+    public async Task<IActionResult> ListSchemas(string clusterId, [FromQuery] KafkaSchemaQueryParams queryParams)
     {
         try
         {
-            var schemas = await _kafkaSchemaService.ListSchemas(queryParams);
+            var schemas = await _kafkaSchemaService.ListSchemas(clusterId, queryParams);
             return Ok(schemas);
         }
         catch (Exception ex)

--- a/src/SelfService/Infrastructure/Api/Kafka/KafkaSchemaController.cs
+++ b/src/SelfService/Infrastructure/Api/Kafka/KafkaSchemaController.cs
@@ -1,0 +1,41 @@
+using Microsoft.AspNetCore.Mvc;
+using SelfService.Application;
+using SelfService.Domain.Models;
+using SelfService.Domain.Queries;
+
+namespace SelfService.Infrastructure.Api.Kafka;
+
+[Route("/kafkaschemas")]
+[ApiController]
+public class KafkaSchemaController : ControllerBase
+{
+    private readonly ILogger<KafkaSchemaController> _logger;
+    private readonly IKafkaSchemaService _kafkaSchemaService;
+
+    public KafkaSchemaController(
+        ILogger<KafkaSchemaController> logger,
+        IKafkaSchemaService kafkaSchemaService
+    )
+    {
+        _logger = logger;
+        _kafkaSchemaService = kafkaSchemaService;
+    }
+
+    [HttpGet("")]
+    [ProducesResponseType(typeof(KafkaSchema[]), StatusCodes.Status200OK, "application/json")]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized, "application/problem+json")]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status500InternalServerError, "application/problem+json")]
+    public async Task<IActionResult> ListSchemas([FromQuery] KafkaSchemaQueryParams queryParams)
+    {
+        try
+        {
+            var schemas = await _kafkaSchemaService.ListSchemas(queryParams);
+            return Ok(schemas);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to list schemas");
+            return Problem("Failed to list schemas", statusCode: StatusCodes.Status500InternalServerError);
+        }
+    }
+}

--- a/src/SelfService/Infrastructure/Kafka/ConfluentGateway.cs
+++ b/src/SelfService/Infrastructure/Kafka/ConfluentGateway.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Text.Json;
+using SelfService.Domain.Models;
+using SelfService.Domain.Queries;
+using SelfService.Domain.Services;
+
+namespace SelfService.Infrastructure.Kafka;
+
+public class ConfluentGateway : IConfluentGatewayService
+{
+    private readonly ILogger<ConfluentGateway> _logger;
+    private readonly HttpClient _httpClient;
+
+    public ConfluentGateway(ILogger<ConfluentGateway> logger, HttpClient httpClient)
+    {
+        _logger = logger;
+        _httpClient = httpClient;
+    }
+
+    public async Task<List<KafkaSchema>> ListSchemas(KafkaSchemaQueryParams queryParams)
+    {
+        using var _ = _logger.BeginScope("{Action} on {ImplementationType}", nameof(ListSchemas), GetType().FullName);
+
+        try
+        {
+            var queryString = "schemas";
+
+            if (!string.IsNullOrWhiteSpace(queryParams.SubjectPrefix))
+            {
+                queryString += $"?subjectPrefix={queryParams.SubjectPrefix}";
+            }
+
+            Console.WriteLine("Listing schemas");
+            Console.WriteLine($"Query string: {queryString}");
+            using HttpResponseMessage response = await _httpClient.GetAsync($"{queryString}");
+
+            response.EnsureSuccessStatusCode();
+            Console.WriteLine("Schemas listed");
+            Console.WriteLine(response.Content.ReadAsStringAsync().Result);
+
+            var options = new JsonSerializerOptions
+            {
+                PropertyNameCaseInsensitive = true
+            };
+
+            var kafkaSchemas = await response.Content.ReadFromJsonAsync<List<KafkaSchema>>(options);
+
+            return kafkaSchemas ?? new List<KafkaSchema>();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to list schemas");
+            throw;
+        }
+    }
+}

--- a/src/SelfService/Infrastructure/Kafka/ConfluentGateway.cs
+++ b/src/SelfService/Infrastructure/Kafka/ConfluentGateway.cs
@@ -6,42 +6,37 @@ using SelfService.Domain.Services;
 
 namespace SelfService.Infrastructure.Kafka;
 
-public class ConfluentGateway : IConfluentGatewayService
+public class ConfluentGatewayService : IConfluentGatewayService
 {
-    private readonly ILogger<ConfluentGateway> _logger;
+    private readonly ILogger<ConfluentGatewayService> _logger;
     private readonly HttpClient _httpClient;
 
-    public ConfluentGateway(ILogger<ConfluentGateway> logger, HttpClient httpClient)
+    public ConfluentGatewayService(ILogger<ConfluentGatewayService> logger, HttpClient httpClient)
     {
         _logger = logger;
         _httpClient = httpClient;
     }
 
-    public async Task<List<KafkaSchema>> ListSchemas(KafkaSchemaQueryParams queryParams)
+    public async Task<List<KafkaSchema>> ListSchemas(string clusterId, KafkaSchemaQueryParams queryParams)
     {
         using var _ = _logger.BeginScope("{Action} on {ImplementationType}", nameof(ListSchemas), GetType().FullName);
 
         try
         {
-            var queryString = "schemas";
+            var queryString = $"clusters/{clusterId}/schemas";
 
+            /* ignore subjectPrefix for now
             if (!string.IsNullOrWhiteSpace(queryParams.SubjectPrefix))
             {
                 queryString += $"?subjectPrefix={queryParams.SubjectPrefix}";
             }
+            */
 
-            Console.WriteLine("Listing schemas");
-            Console.WriteLine($"Query string: {queryString}");
             using HttpResponseMessage response = await _httpClient.GetAsync($"{queryString}");
 
             response.EnsureSuccessStatusCode();
-            Console.WriteLine("Schemas listed");
-            Console.WriteLine(response.Content.ReadAsStringAsync().Result);
 
-            var options = new JsonSerializerOptions
-            {
-                PropertyNameCaseInsensitive = true
-            };
+            var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
 
             var kafkaSchemas = await response.Content.ReadFromJsonAsync<List<KafkaSchema>>(options);
 

--- a/src/SelfService/Properties/launchSettings.json
+++ b/src/SelfService/Properties/launchSettings.json
@@ -28,7 +28,8 @@
         "SS_ARM_GIT_USERNAME": "selfservice-api",
         "SS_ARM_GIT_EMAIL": "ssu@dfds.cloud",
         "SS_ARM_GIT_BRANCH": "master",
-        "SS_AWS_TYPE": "mock"
+        "SS_AWS_TYPE": "mock",
+        "SS_CONFLUENT_GATEWAY_API_ENDPOINT": "http://localhost:8081",
       }
     }
   }

--- a/src/SelfService/Properties/launchSettings.json
+++ b/src/SelfService/Properties/launchSettings.json
@@ -29,7 +29,7 @@
         "SS_ARM_GIT_EMAIL": "ssu@dfds.cloud",
         "SS_ARM_GIT_BRANCH": "master",
         "SS_AWS_TYPE": "mock",
-        "SS_CONFLUENT_GATEWAY_API_ENDPOINT": "http://localhost:8081",
+        "SS_CONFLUENT_GATEWAY_API_ENDPOINT": "http://localhost:8080",
       }
     }
   }


### PR DESCRIPTION
# Additional Review Notes
Uses new confluent-gateway endpoint to fetch schemas.
Schemas are fetched when requested by the frontend and based on cluster.
No filtering is happening at this time.