### PR TITLE
Fix/handle self assessments as non boolean

### DIFF
--- a/src/SelfService/Application/CapabilityApplicationService.cs
+++ b/src/SelfService/Application/CapabilityApplicationService.cs
@@ -331,7 +331,10 @@ public class CapabilityApplicationService : ICapabilityApplicationService
         return configLevelInfo;
     }
 
-    public async Task<bool> SelfAssessmentOptionExists(CapabilityId capabilityId, SelfAssessmentOptionId selfAssessmentOptionId)
+    public async Task<bool> SelfAssessmentOptionExists(
+        CapabilityId capabilityId,
+        SelfAssessmentOptionId selfAssessmentOptionId
+    )
     {
         var selfAssessmentOptions = await _selfAssessmentOptionRepository.GetAllSelfAssessmentOptions();
         if (selfAssessmentOptions.Any(o => o.Id == selfAssessmentOptionId))
@@ -365,7 +368,7 @@ public class CapabilityApplicationService : ICapabilityApplicationService
             newAssessment = false;
             selfAssessmentID = assessment.Id;
         }
-        
+
         var option = await _selfAssessmentOptionRepository.Get(selfAssessmentOptionId);
         if (option is null)
         {
@@ -384,7 +387,9 @@ public class CapabilityApplicationService : ICapabilityApplicationService
         if (newAssessment)
         {
             await _selfAssessmentRepository.AddSelfAssessment(selfAssessment);
-        } else {
+        }
+        else
+        {
             await _selfAssessmentRepository.UpdateSelfAssessment(selfAssessment);
         }
         return selfAssessment.Id;

--- a/src/SelfService/Application/CapabilityApplicationService.cs
+++ b/src/SelfService/Application/CapabilityApplicationService.cs
@@ -331,35 +331,10 @@ public class CapabilityApplicationService : ICapabilityApplicationService
         return configLevelInfo;
     }
 
-    public async Task<bool> CanSelfAssessType(CapabilityId capabilityId, SelfAssessmentOptionId selfAssessmentOptionId)
+    public async Task<bool> SelfAssessmentOptionExists(CapabilityId capabilityId, SelfAssessmentOptionId selfAssessmentOptionId)
     {
         var selfAssessmentOptions = await _selfAssessmentOptionRepository.GetAllSelfAssessmentOptions();
-        var isAllowedToAssess = selfAssessmentOptions.Any(o => o.Id == selfAssessmentOptionId);
-        var notAlreadyAssessed = !await _selfAssessmentRepository.SelfAssessmentExists(
-            capabilityId,
-            selfAssessmentOptionId
-        );
-
-        if (isAllowedToAssess && notAlreadyAssessed)
-        {
-            return true;
-        }
-        return false;
-    }
-
-    public async Task<bool> CanRemoveSelfAssessmentType(
-        CapabilityId capabilityId,
-        SelfAssessmentOptionId selfAssessmentOptionId
-    )
-    {
-        var selfAssessmentOptions = await _selfAssessmentOptionRepository.GetAllSelfAssessmentOptions();
-        var isAllowedToAssess = selfAssessmentOptions.Any(o => o.Id == selfAssessmentOptionId);
-        var alreadyAssessed = await _selfAssessmentRepository.SelfAssessmentExists(
-            capabilityId,
-            selfAssessmentOptionId
-        );
-
-        if (isAllowedToAssess && alreadyAssessed)
+        if (selfAssessmentOptions.Any(o => o.Id == selfAssessmentOptionId))
         {
             return true;
         }
@@ -379,8 +354,18 @@ public class CapabilityApplicationService : ICapabilityApplicationService
         SelfAssessmentStatus status
     )
     {
+        var newAssessment = true;
         var selfAssessmentID = new SelfAssessmentId(Guid.NewGuid());
-
+        var assessment = await _selfAssessmentRepository.GetSpecificSelfAssessmentForCapability(
+            capabilityId,
+            selfAssessmentOptionId
+        );
+        if (assessment is not null)
+        {
+            newAssessment = false;
+            selfAssessmentID = assessment.Id;
+        }
+        
         var option = await _selfAssessmentOptionRepository.Get(selfAssessmentOptionId);
         if (option is null)
         {
@@ -396,7 +381,12 @@ public class CapabilityApplicationService : ICapabilityApplicationService
             userId,
             status
         );
-        await _selfAssessmentRepository.UpdateSelfAssessment(selfAssessment);
+        if (newAssessment)
+        {
+            await _selfAssessmentRepository.AddSelfAssessment(selfAssessment);
+        } else {
+            await _selfAssessmentRepository.UpdateSelfAssessment(selfAssessment);
+        }
         return selfAssessment.Id;
     }
 }

--- a/src/SelfService/Application/ConfigurationLevelService.cs
+++ b/src/SelfService/Application/ConfigurationLevelService.cs
@@ -9,7 +9,8 @@ public enum ConfigurationLevel
 {
     None,
     Partial,
-    Complete
+    Complete,
+    Unknown,
 }
 
 public class ConfigurationLevelDetail : Entity<ConfigurationLevelDetail>
@@ -188,6 +189,22 @@ public class ConfigurationLevelService : IConfigurationLevelService
         );
     }
 
+    private ConfigurationLevel translateStatus(SelfAssessmentStatus status) {
+        if (status == SelfAssessmentStatus.NotApplicable)
+        {
+            return ConfigurationLevel.Partial;
+        }
+        if (status == SelfAssessmentStatus.Satisfied)
+        {
+            return ConfigurationLevel.Complete;
+        }
+        if (status == SelfAssessmentStatus.Violated)
+        {
+            return ConfigurationLevel.None;
+        }
+        return ConfigurationLevel.Unknown;
+    }
+
     public async Task<List<ConfigurationLevelDetail>> GetSelfAssessmentMetrics(CapabilityId capabilityId)
     {
         var metrics = new List<ConfigurationLevelDetail> { };
@@ -197,11 +214,32 @@ public class ConfigurationLevelService : IConfigurationLevelService
 
         foreach (SelfAssessmentOption option in selfAssessmentOptions)
         {
-            var isAssessed = assessments.Any(c => c.OptionId == option.Id);
-            var configurationLevel = isAssessed ? ConfigurationLevel.Complete : ConfigurationLevel.None;
-
+            var exists = assessments.Any(a => a.OptionId == option.Id);
+            if (!exists)
+            {
+                metrics.Add(
+                    new ConfigurationLevelDetail(
+                        ConfigurationLevel.Unknown,
+                        option.ShortName,
+                        option.Description,
+                        false,
+                        true
+                    )
+                );
+                continue;
+            }
+        }
+        foreach (SelfAssessment assessment in assessments)
+        {
+            var option = selfAssessmentOptions.First(o => o.Id == assessment.OptionId);
             metrics.Add(
-                new ConfigurationLevelDetail(configurationLevel, option.ShortName, option.Description, false, true)
+                new ConfigurationLevelDetail(
+                    translateStatus(assessment.Status),
+                    option.ShortName,
+                    option.Description,
+                    false,
+                    true
+                )
             );
         }
 

--- a/src/SelfService/Application/ConfigurationLevelService.cs
+++ b/src/SelfService/Application/ConfigurationLevelService.cs
@@ -189,7 +189,8 @@ public class ConfigurationLevelService : IConfigurationLevelService
         );
     }
 
-    private ConfigurationLevel translateStatus(SelfAssessmentStatus status) {
+    private ConfigurationLevel translateStatus(SelfAssessmentStatus status)
+    {
         if (status == SelfAssessmentStatus.NotApplicable)
         {
             return ConfigurationLevel.Partial;

--- a/src/SelfService/Application/ICapabilityApplicationService.cs
+++ b/src/SelfService/Application/ICapabilityApplicationService.cs
@@ -34,8 +34,7 @@ public interface ICapabilityApplicationService
     Task<bool> DoesOnlyModifyRequiredProperties(string jsonMetadata, CapabilityId capabilityId);
     Task<ConfigurationLevelInfo> GetConfigurationLevel(CapabilityId capabilityId);
 
-    Task<bool> CanSelfAssessType(CapabilityId capabilityId, SelfAssessmentOptionId selfAssessmentOptionId);
-    Task<bool> CanRemoveSelfAssessmentType(CapabilityId capabilityId, SelfAssessmentOptionId selfAssessmentOptionId);
+    Task<bool> SelfAssessmentOptionExists(CapabilityId capabilityId, SelfAssessmentOptionId selfAssessmentOptionId);
     Task<List<SelfAssessment>> GetAllSelfAssessments(CapabilityId capabilityId);
 
     Task<SelfAssessmentId> UpdateSelfAssessment(

--- a/src/SelfService/Domain/Models/ISelfAssessmentRepository.cs
+++ b/src/SelfService/Domain/Models/ISelfAssessmentRepository.cs
@@ -2,6 +2,7 @@ namespace SelfService.Domain.Models;
 
 public interface ISelfAssessmentRepository
 {
+    Task AddSelfAssessment(SelfAssessment assessment);
     Task UpdateSelfAssessment(SelfAssessment assessment);
 
     Task<bool> SelfAssessmentExists(CapabilityId capabilityId, SelfAssessmentOptionId selfAssessmentOptionId);

--- a/src/SelfService/Domain/Models/SelfAssessment.cs
+++ b/src/SelfService/Domain/Models/SelfAssessment.cs
@@ -24,7 +24,7 @@ public class SelfAssessment : AggregateRoot<SelfAssessmentId>
     public SelfAssessmentOptionId OptionId { get; private set; }
     public CapabilityId CapabilityId { get; private set; }
     public string ShortName { get; private set; }
-    public DateTime RequestedAt { get; private set; }
+    public DateTime RequestedAt { get; set; }
     public string RequestedBy { get; private set; }
-    public string Status { get; private set; }
+    public string Status { get; set; }
 }

--- a/src/SelfService/Domain/Models/SelfAssessmentStatus.cs
+++ b/src/SelfService/Domain/Models/SelfAssessmentStatus.cs
@@ -2,9 +2,9 @@ namespace SelfService.Domain.Models;
 
 public class SelfAssessmentStatus : ValueObject
 {
-    public static readonly SelfAssessmentStatus NotApplicable = new("Not Applicable");
-    public static readonly SelfAssessmentStatus Satisfied = new("Satisfied");
-    public static readonly SelfAssessmentStatus Violated = new("Violated");
+    public static readonly SelfAssessmentStatus NotApplicable = new("NOT_APPLICABLE");
+    public static readonly SelfAssessmentStatus Satisfied = new("SATISFIED");
+    public static readonly SelfAssessmentStatus Violated = new("VIOLATED");
 
     private readonly string _value;
 

--- a/src/SelfService/Infrastructure/Api/ApiResourceFactory.cs
+++ b/src/SelfService/Infrastructure/Api/ApiResourceFactory.cs
@@ -164,6 +164,7 @@ public class ApiResourceFactory
         foreach (var option in selfAssessmentOptions)
         {
             var selfAssessmentResource = new SelfAssessmentsApiResource(
+                id: option.Id,
                 shortName: option.ShortName,
                 description: option.Description,
                 documentationUrl: option.DocumentationUrl,

--- a/src/SelfService/Infrastructure/Api/Capabilities/CapabilityController.cs
+++ b/src/SelfService/Infrastructure/Api/Capabilities/CapabilityController.cs
@@ -468,11 +468,11 @@ public class CapabilityController : ControllerBase
             return NotFound();
 
         if (!await _capabilityApplicationService.SelfAssessmentOptionExists(capabilityId, selfAssessmentOptionId))
-             return BadRequest();
+            return BadRequest();
 
         if (!SelfAssessmentStatus.TryParse(selfAssessmentRequest.SelfAssessmentStatus, out var selfAssessmentStatus))
             return BadRequest();
- 
+
         await _capabilityApplicationService.UpdateSelfAssessment(
             capabilityId,
             selfAssessmentOptionId,

--- a/src/SelfService/Infrastructure/Api/Capabilities/CapabilityController.cs
+++ b/src/SelfService/Infrastructure/Api/Capabilities/CapabilityController.cs
@@ -467,14 +467,12 @@ public class CapabilityController : ControllerBase
         )
             return NotFound();
 
-        if (!await _capabilityApplicationService.CanSelfAssessType(capabilityId, selfAssessmentOptionId))
-        {
-            return BadRequest();
-        }
+        if (!await _capabilityApplicationService.SelfAssessmentOptionExists(capabilityId, selfAssessmentOptionId))
+             return BadRequest();
 
         if (!SelfAssessmentStatus.TryParse(selfAssessmentRequest.SelfAssessmentStatus, out var selfAssessmentStatus))
             return BadRequest();
-
+ 
         await _capabilityApplicationService.UpdateSelfAssessment(
             capabilityId,
             selfAssessmentOptionId,

--- a/src/SelfService/Infrastructure/Api/Capabilities/SelfAssessmentApiResource.cs
+++ b/src/SelfService/Infrastructure/Api/Capabilities/SelfAssessmentApiResource.cs
@@ -5,6 +5,7 @@ namespace SelfService.Infrastructure.Api.Capabilities;
 
 public class SelfAssessmentsApiResource
 {
+    public string Id { get; set; }
     public string ShortName { get; set; }
     public DateTime? AssessedAt { get; set; }
     public string Description { get; set; }
@@ -26,6 +27,7 @@ public class SelfAssessmentsApiResource
     }
 
     public SelfAssessmentsApiResource(
+        SelfAssessmentOptionId id,
         string shortName,
         string description,
         string documentationUrl,
@@ -34,6 +36,7 @@ public class SelfAssessmentsApiResource
         SelfAssessmentLinks links
     )
     {
+        Id = id.ToString();
         ShortName = shortName;
         Description = description;
         DocumentationUrl = documentationUrl;

--- a/src/SelfService/Infrastructure/Persistence/SelfAssessmentRepository.cs
+++ b/src/SelfService/Infrastructure/Persistence/SelfAssessmentRepository.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.EntityFrameworkCore;
 using SelfService.Domain.Models;
 
@@ -12,9 +13,22 @@ public class SelfAssessmentRepository : ISelfAssessmentRepository
         _dbContext = dbContext;
     }
 
-    public async Task UpdateSelfAssessment(SelfAssessment selfAssessment)
+    public async Task AddSelfAssessment(SelfAssessment selfAssessment)
     {
         await _dbContext.SelfAssessments.AddAsync(selfAssessment);
+        await _dbContext.SaveChangesAsync();
+    }
+
+    public async Task UpdateSelfAssessment(SelfAssessment selfAssessment)
+    {
+        var assessment = await _dbContext.SelfAssessments.FindAsync(selfAssessment.Id);
+        if (assessment is null)
+        {
+            throw new InvalidOperationException($"Self-assessment with id {selfAssessment.Id} not found.");
+        }
+
+        assessment.Status = selfAssessment.Status;
+        assessment.RequestedAt = DateTime.UtcNow;
         await _dbContext.SaveChangesAsync();
     }
 


### PR DESCRIPTION
# Additional Review Notes
- Self Assessment enum is now spelled in a computer friendly way
- Permissions now correctly handles existing assessments
- Assessments are no longer boolean and the logic should reflect this