### PR TITLE
always return aws account id in capability list

### DIFF
--- a/src/SelfService/Infrastructure/Api/ApiResourceFactory.cs
+++ b/src/SelfService/Infrastructure/Api/ApiResourceFactory.cs
@@ -286,7 +286,7 @@ public class ApiResourceFactory
         );
     }
 
-    public async Task<CapabilityListApiResource> Convert(IEnumerable<Capability> capabilities)
+    public CapabilityListApiResource Convert(IEnumerable<Capability> capabilities)
     {
         var showDeleted = _authorizationService.CanViewDeletedCapabilities(PortalUser);
         capabilities = showDeleted

--- a/src/SelfService/Infrastructure/Api/ApiResourceFactory.cs
+++ b/src/SelfService/Infrastructure/Api/ApiResourceFactory.cs
@@ -297,8 +297,7 @@ public class ApiResourceFactory
 
         foreach (var capability in capabilitiesSelected)
         {
-            var showAwsAccountId = await _authorizationService.CanSeeAwsAccountId(PortalUser, capability.Id);
-            var awsAccountId = showAwsAccountId ? _awsAccountIdQuery.FindBy(capability.Id) : null;
+            var awsAccountId = _awsAccountIdQuery.FindBy(capability.Id);
             capability.AwsAccountId = awsAccountId == null ? "" : awsAccountId.ToString();
         }
 

--- a/src/SelfService/Infrastructure/Api/Capabilities/CapabilityController.cs
+++ b/src/SelfService/Infrastructure/Api/Capabilities/CapabilityController.cs
@@ -87,7 +87,7 @@ public class CapabilityController : ControllerBase
     {
         var capabilities = await _capabilityRepository.GetAll();
 
-        return Ok(await _apiResourceFactory.Convert(capabilities));
+        return Ok(_apiResourceFactory.Convert(capabilities));
     }
 
     [HttpPost("")]

--- a/src/SelfService/Infrastructure/Api/Teams/TeamController.cs
+++ b/src/SelfService/Infrastructure/Api/Teams/TeamController.cs
@@ -183,7 +183,7 @@ public class TeamController : ControllerBase
 
         var capabilities = await _teamApplicationService.GetLinkedCapabilities(teamId);
 
-        return Ok(await _apiResourceFactory.Convert(capabilities));
+        return Ok(_apiResourceFactory.Convert(capabilities));
     }
 
     [HttpGet("{id}/members")]


### PR DESCRIPTION
closes dfds/cloudplatform/issues/3107

# Additional Review Notes
We expect people to be able to search capabilities by AWS Account ID.
Therefore we should not hide it away.