### PR TITLE
sunset date should not be a requirement as it is not used

### DIFF
--- a/src/SelfService/Application/AzureResourceApplicationService.cs
+++ b/src/SelfService/Application/AzureResourceApplicationService.cs
@@ -49,13 +49,7 @@ public class AzureResourceApplicationService : IAzureResourceApplicationService
 
         var capability = await _capabilityRepository.Get(capabilityId);
         var jsonObject = JsonNode.Parse(capability!.JsonMetadata)?.AsObject()!;
-        var mandatoryTags = new List<String>
-        {
-            "dfds.planned_sunset",
-            "dfds.owner",
-            "dfds.cost.centre",
-            "dfds.service.availability",
-        };
+        var mandatoryTags = new List<String> { "dfds.owner", "dfds.cost.centre", "dfds.service.availability" };
         foreach (var tag in mandatoryTags)
         {
             if (!jsonObject.ContainsKey(tag))


### PR DESCRIPTION
Required to roll out a frontend that does not stop Azure Request Group requests lacking sunset date.