### PR TITLE
User Rbac for auth and remember stubs

### DIFF
--- a/src/SelfService.Tests/Infrastructure/Api/TestCapabilityAwsAccountRoutes.cs
+++ b/src/SelfService.Tests/Infrastructure/Api/TestCapabilityAwsAccountRoutes.cs
@@ -20,6 +20,7 @@ public class TestCapabilityAwsAccountRoutes
             .Build();
         application.ReplaceService<IRbacPermissionGrantRepository>(new StubRbacPermissionGrantRepository());
         application.ReplaceService<IRbacRoleGrantRepository>(new StubRbacRoleGrantRepository());
+        application.ReplaceService<IPermissionQuery>(new StubPermissionQuery());
 
         using var client = application.CreateClient();
         var response = await client.GetAsync($"/capabilities/{stubCapability.Id}");
@@ -44,6 +45,7 @@ public class TestCapabilityAwsAccountRoutes
             .Build();
         application.ReplaceService<IRbacPermissionGrantRepository>(new StubRbacPermissionGrantRepository());
         application.ReplaceService<IRbacRoleGrantRepository>(new StubRbacRoleGrantRepository());
+        application.ReplaceService<IPermissionQuery>(new StubPermissionQuery());
 
         using var client = application.CreateClient();
         var response = await client.GetAsync($"/capabilities/{stubCapability.Id}");
@@ -75,6 +77,7 @@ public class TestCapabilityAwsAccountRoutes
         application.ReplaceService<IRbacRoleGrantRepository>(new StubRbacRoleGrantRepository());
         application.ReplaceService<IRbacPermissionGrantRepository>(new StubRbacPermissionGrantRepository());
         application.ReplaceService<IRbacRoleGrantRepository>(new StubRbacRoleGrantRepository());
+        application.ReplaceService<IPermissionQuery>(new StubPermissionQuery());
 
         using var client = application.CreateClient();
         var response = await client.GetAsync($"/capabilities/{stubCapability.Id}");
@@ -103,6 +106,7 @@ public class TestCapabilityAwsAccountRoutes
             .Build();
         application.ReplaceService<IRbacPermissionGrantRepository>(new StubRbacPermissionGrantRepository());
         application.ReplaceService<IRbacRoleGrantRepository>(new StubRbacRoleGrantRepository());
+        application.ReplaceService<IPermissionQuery>(new StubPermissionQuery());
 
         using var client = application.CreateClient();
         var response = await client.GetAsync($"/capabilities/{stubCapability.Id}");
@@ -131,6 +135,7 @@ public class TestCapabilityAwsAccountRoutes
             .Build();
         application.ReplaceService<IRbacPermissionGrantRepository>(new StubRbacPermissionGrantRepository());
         application.ReplaceService<IRbacRoleGrantRepository>(new StubRbacRoleGrantRepository());
+        application.ReplaceService<IPermissionQuery>(new StubPermissionQuery());
 
         using var client = application.CreateClient();
         var response = await client.GetAsync($"/capabilities/{stubCapability.Id}");
@@ -160,6 +165,7 @@ public class TestCapabilityAwsAccountRoutes
             .Build();
         application.ReplaceService<IRbacPermissionGrantRepository>(new StubRbacPermissionGrantRepository());
         application.ReplaceService<IRbacRoleGrantRepository>(new StubRbacRoleGrantRepository());
+        application.ReplaceService<IPermissionQuery>(new StubPermissionQuery());
 
         using var client = application.CreateClient();
         var response = await client.GetAsync($"/capabilities/{stubCapability.Id}");
@@ -189,6 +195,7 @@ public class TestCapabilityAwsAccountRoutes
             .Build();
         application.ReplaceService<IRbacPermissionGrantRepository>(new StubRbacPermissionGrantRepository());
         application.ReplaceService<IRbacRoleGrantRepository>(new StubRbacRoleGrantRepository());
+        application.ReplaceService<IPermissionQuery>(new StubPermissionQuery());
 
         using var client = application.CreateClient();
         var response = await client.GetAsync($"/capabilities/{stubCapability.Id}");
@@ -218,6 +225,7 @@ public class TestCapabilityAwsAccountRoutes
             .Build();
         application.ReplaceService<IRbacPermissionGrantRepository>(new StubRbacPermissionGrantRepository());
         application.ReplaceService<IRbacRoleGrantRepository>(new StubRbacRoleGrantRepository());
+        application.ReplaceService<IPermissionQuery>(new StubPermissionQuery());
 
         using var client = application.CreateClient();
         var response = await client.GetAsync($"/capabilities/{stubCapability.Id}");

--- a/src/SelfService.Tests/Infrastructure/Api/TestCapabilityInvitationRoutes.cs
+++ b/src/SelfService.Tests/Infrastructure/Api/TestCapabilityInvitationRoutes.cs
@@ -19,6 +19,7 @@ public class TestCapabilityInvitationRoutes
             .Build();
         application.ReplaceService<IRbacPermissionGrantRepository>(new StubRbacPermissionGrantRepository());
         application.ReplaceService<IRbacRoleGrantRepository>(new StubRbacRoleGrantRepository());
+        application.ReplaceService<IPermissionQuery>(new StubPermissionQuery());
 
         using var client = application.CreateClient();
         var response = await client.GetAsync($"/capabilities/{stubCapability.Id}");
@@ -43,6 +44,7 @@ public class TestCapabilityInvitationRoutes
             .Build();
         application.ReplaceService<IRbacPermissionGrantRepository>(new StubRbacPermissionGrantRepository());
         application.ReplaceService<IRbacRoleGrantRepository>(new StubRbacRoleGrantRepository());
+        application.ReplaceService<IPermissionQuery>(new StubPermissionQuery());
 
         using var client = application.CreateClient();
         var response = await client.GetAsync($"/capabilities/{stubCapability.Id}");
@@ -72,6 +74,7 @@ public class TestCapabilityInvitationRoutes
             .Build();
         application.ReplaceService<IRbacPermissionGrantRepository>(new StubRbacPermissionGrantRepository());
         application.ReplaceService<IRbacRoleGrantRepository>(new StubRbacRoleGrantRepository());
+        application.ReplaceService<IPermissionQuery>(new StubPermissionQuery());
 
         using var client = application.CreateClient();
         var response = await client.GetAsync($"/capabilities/{stubCapability.Id}");

--- a/src/SelfService.Tests/Infrastructure/Api/TestCapabilityMembersRoutes.cs
+++ b/src/SelfService.Tests/Infrastructure/Api/TestCapabilityMembersRoutes.cs
@@ -19,6 +19,7 @@ public class TestCapabilityMembersRoutes
             .Build();
         application.ReplaceService<IRbacPermissionGrantRepository>(new StubRbacPermissionGrantRepository());
         application.ReplaceService<IRbacRoleGrantRepository>(new StubRbacRoleGrantRepository());
+        application.ReplaceService<IPermissionQuery>(new StubPermissionQuery());
 
         using var client = application.CreateClient();
         var response = await client.GetAsync($"/capabilities/{stubCapability.Id}");
@@ -43,6 +44,7 @@ public class TestCapabilityMembersRoutes
             .Build();
         application.ReplaceService<IRbacPermissionGrantRepository>(new StubRbacPermissionGrantRepository());
         application.ReplaceService<IRbacRoleGrantRepository>(new StubRbacRoleGrantRepository());
+        application.ReplaceService<IPermissionQuery>(new StubPermissionQuery());
 
         using var client = application.CreateClient();
         var response = await client.GetAsync($"/capabilities/{stubCapability.Id}");
@@ -71,6 +73,7 @@ public class TestCapabilityMembersRoutes
             .Build();
         application.ReplaceService<IRbacPermissionGrantRepository>(new StubRbacPermissionGrantRepository());
         application.ReplaceService<IRbacRoleGrantRepository>(new StubRbacRoleGrantRepository());
+        application.ReplaceService<IPermissionQuery>(new StubPermissionQuery());
 
         using var client = application.CreateClient();
         var response = await client.GetAsync($"/capabilities/{stubCapability.Id}");
@@ -99,6 +102,7 @@ public class TestCapabilityMembersRoutes
             .Build();
         application.ReplaceService<IRbacPermissionGrantRepository>(new StubRbacPermissionGrantRepository());
         application.ReplaceService<IRbacRoleGrantRepository>(new StubRbacRoleGrantRepository());
+        application.ReplaceService<IPermissionQuery>(new StubPermissionQuery());
 
         using var client = application.CreateClient();
         var response = await client.GetAsync($"/capabilities/{stubCapability.Id}");

--- a/src/SelfService.Tests/Infrastructure/Api/TestCapabilityMembershipApplicationRoutes.cs
+++ b/src/SelfService.Tests/Infrastructure/Api/TestCapabilityMembershipApplicationRoutes.cs
@@ -19,6 +19,7 @@ public class TestCapabilityMembershipApplicationRoutes
             .Build();
         application.ReplaceService<IRbacPermissionGrantRepository>(new StubRbacPermissionGrantRepository());
         application.ReplaceService<IRbacRoleGrantRepository>(new StubRbacRoleGrantRepository());
+        application.ReplaceService<IPermissionQuery>(new StubPermissionQuery());
 
         using var client = application.CreateClient();
         var response = await client.GetAsync($"/capabilities/{stubCapability.Id}");
@@ -43,6 +44,7 @@ public class TestCapabilityMembershipApplicationRoutes
             .Build();
         application.ReplaceService<IRbacPermissionGrantRepository>(new StubRbacPermissionGrantRepository());
         application.ReplaceService<IRbacRoleGrantRepository>(new StubRbacRoleGrantRepository());
+        application.ReplaceService<IPermissionQuery>(new StubPermissionQuery());
 
         using var client = application.CreateClient();
         var response = await client.GetAsync($"/capabilities/{stubCapability.Id}");
@@ -70,6 +72,7 @@ public class TestCapabilityMembershipApplicationRoutes
             .Build();
         application.ReplaceService<IRbacPermissionGrantRepository>(new StubRbacPermissionGrantRepository());
         application.ReplaceService<IRbacRoleGrantRepository>(new StubRbacRoleGrantRepository());
+        application.ReplaceService<IPermissionQuery>(new StubPermissionQuery());
 
         using var client = application.CreateClient();
         var response = await client.GetAsync($"/capabilities/{stubCapability.Id}");
@@ -97,6 +100,7 @@ public class TestCapabilityMembershipApplicationRoutes
             .Build();
         application.ReplaceService<IRbacPermissionGrantRepository>(new StubRbacPermissionGrantRepository());
         application.ReplaceService<IRbacRoleGrantRepository>(new StubRbacRoleGrantRepository());
+        application.ReplaceService<IPermissionQuery>(new StubPermissionQuery());
 
         using var client = application.CreateClient();
         var response = await client.GetAsync($"/capabilities/{stubCapability.Id}");
@@ -125,6 +129,7 @@ public class TestCapabilityMembershipApplicationRoutes
         );
         application.ReplaceService<IRbacPermissionGrantRepository>(new StubRbacPermissionGrantRepository());
         application.ReplaceService<IRbacRoleGrantRepository>(new StubRbacRoleGrantRepository());
+        application.ReplaceService<IPermissionQuery>(new StubPermissionQuery());
 
         using var client = application.CreateClient();
         var response = await client.GetAsync($"/capabilities/{stubCapability.Id}/membershipapplications");
@@ -150,6 +155,7 @@ public class TestCapabilityMembershipApplicationRoutes
         );
         application.ReplaceService<IRbacPermissionGrantRepository>(new StubRbacPermissionGrantRepository());
         application.ReplaceService<IRbacRoleGrantRepository>(new StubRbacRoleGrantRepository());
+        application.ReplaceService<IPermissionQuery>(new StubPermissionQuery());
 
         using var client = application.CreateClient();
         var response = await client.GetAsync($"/capabilities/{stubCapability.Id}/membershipapplications");
@@ -175,6 +181,7 @@ public class TestCapabilityMembershipApplicationRoutes
         );
         application.ReplaceService<IRbacPermissionGrantRepository>(new StubRbacPermissionGrantRepository());
         application.ReplaceService<IRbacRoleGrantRepository>(new StubRbacRoleGrantRepository());
+        application.ReplaceService<IPermissionQuery>(new StubPermissionQuery());
 
         using var client = application.CreateClient();
         var response = await client.GetAsync($"/capabilities/{stubCapability.Id}/membershipapplications");
@@ -206,6 +213,7 @@ public class TestCapabilityMembershipApplicationRoutes
         );
         application.ReplaceService<IRbacPermissionGrantRepository>(new StubRbacPermissionGrantRepository());
         application.ReplaceService<IRbacRoleGrantRepository>(new StubRbacRoleGrantRepository());
+        application.ReplaceService<IPermissionQuery>(new StubPermissionQuery());
 
         using var client = application.CreateClient();
         var response = await client.GetAsync($"/capabilities/{stubCapability.Id}/membershipapplications");
@@ -231,6 +239,7 @@ public class TestCapabilityMembershipApplicationRoutes
         );
         application.ReplaceService<IRbacPermissionGrantRepository>(new StubRbacPermissionGrantRepository());
         application.ReplaceService<IRbacRoleGrantRepository>(new StubRbacRoleGrantRepository());
+        application.ReplaceService<IPermissionQuery>(new StubPermissionQuery());
 
         using var client = application.CreateClient();
         var response = await client.GetAsync($"/capabilities/foo/membershipapplications");
@@ -271,6 +280,7 @@ public class TestCapabilityMembershipApplicationRoutes
         );
         application.ReplaceService<IRbacPermissionGrantRepository>(new StubRbacPermissionGrantRepository());
         application.ReplaceService<IRbacRoleGrantRepository>(new StubRbacRoleGrantRepository());
+        application.ReplaceService<IPermissionQuery>(new StubPermissionQuery());
 
         using var client = application.CreateClient();
         var response = await client.GetAsync($"/capabilities/foo/membershipapplications");
@@ -296,6 +306,7 @@ public class TestCapabilityMembershipApplicationRoutes
         );
         application.ReplaceService<IRbacPermissionGrantRepository>(new StubRbacPermissionGrantRepository());
         application.ReplaceService<IRbacRoleGrantRepository>(new StubRbacRoleGrantRepository());
+        application.ReplaceService<IPermissionQuery>(new StubPermissionQuery());
 
         using var client = application.CreateClient();
         var response = await client.GetAsync($"/capabilities/foo/membershipapplications");
@@ -324,6 +335,7 @@ public class TestCapabilityMembershipApplicationRoutes
         );
         application.ReplaceService<IRbacPermissionGrantRepository>(new StubRbacPermissionGrantRepository());
         application.ReplaceService<IRbacRoleGrantRepository>(new StubRbacRoleGrantRepository());
+        application.ReplaceService<IPermissionQuery>(new StubPermissionQuery());
 
         using var client = application.CreateClient();
         var response = await client.GetAsync($"/capabilities/foo/membershipapplications");

--- a/src/SelfService.Tests/Infrastructure/Api/TestCapabilityMembershipsRoutes.cs
+++ b/src/SelfService.Tests/Infrastructure/Api/TestCapabilityMembershipsRoutes.cs
@@ -19,6 +19,7 @@ public class TestCapabilityMembershipsRoutes
             .Build();
         application.ReplaceService<IRbacPermissionGrantRepository>(new StubRbacPermissionGrantRepository());
         application.ReplaceService<IRbacRoleGrantRepository>(new StubRbacRoleGrantRepository());
+        application.ReplaceService<IPermissionQuery>(new StubPermissionQuery());
 
         using var client = application.CreateClient();
         var response = await client.GetAsync($"/capabilities/{stubCapability.Id}");
@@ -47,6 +48,7 @@ public class TestCapabilityMembershipsRoutes
             .Build();
         application.ReplaceService<IRbacPermissionGrantRepository>(new StubRbacPermissionGrantRepository());
         application.ReplaceService<IRbacRoleGrantRepository>(new StubRbacRoleGrantRepository());
+        application.ReplaceService<IPermissionQuery>(new StubPermissionQuery());
 
         using var client = application.CreateClient();
         var response = await client.GetAsync($"/capabilities/{stubCapability.Id}");
@@ -75,6 +77,7 @@ public class TestCapabilityMembershipsRoutes
             .Build();
         application.ReplaceService<IRbacPermissionGrantRepository>(new StubRbacPermissionGrantRepository());
         application.ReplaceService<IRbacRoleGrantRepository>(new StubRbacRoleGrantRepository());
+        application.ReplaceService<IPermissionQuery>(new StubPermissionQuery());
 
         using var client = application.CreateClient();
         var response = await client.GetAsync($"/capabilities/{stubCapability.Id}");

--- a/src/SelfService.Tests/Infrastructure/Api/TestCapabilityRoutes.cs
+++ b/src/SelfService.Tests/Infrastructure/Api/TestCapabilityRoutes.cs
@@ -17,6 +17,7 @@ public class TestCapabilityRoutes
         application.ReplaceService<ICapabilityRepository>(new StubCapabilityRepository());
         application.ReplaceService<IRbacPermissionGrantRepository>(new StubRbacPermissionGrantRepository());
         application.ReplaceService<IRbacRoleGrantRepository>(new StubRbacRoleGrantRepository());
+        application.ReplaceService<IPermissionQuery>(new StubPermissionQuery());
 
         using var client = application.CreateClient();
 
@@ -34,6 +35,7 @@ public class TestCapabilityRoutes
             .Build();
         application.ReplaceService<IRbacPermissionGrantRepository>(new StubRbacPermissionGrantRepository());
         application.ReplaceService<IRbacRoleGrantRepository>(new StubRbacRoleGrantRepository());
+        application.ReplaceService<IPermissionQuery>(new StubPermissionQuery());
 
         using var client = application.CreateClient();
 
@@ -54,6 +56,7 @@ public class TestCapabilityRoutes
             .Build();
         application.ReplaceService<IRbacPermissionGrantRepository>(new StubRbacPermissionGrantRepository());
         application.ReplaceService<IRbacRoleGrantRepository>(new StubRbacRoleGrantRepository());
+        application.ReplaceService<IPermissionQuery>(new StubPermissionQuery());
 
         using var client = application.CreateClient();
         var response = await client.GetAsync($"/capabilities/{stubCapability.Id}");
@@ -83,6 +86,7 @@ public class TestCapabilityRoutes
             .Build();
         application.ReplaceService<IRbacPermissionGrantRepository>(new StubRbacPermissionGrantRepository());
         application.ReplaceService<IRbacRoleGrantRepository>(new StubRbacRoleGrantRepository());
+        application.ReplaceService<IPermissionQuery>(new StubPermissionQuery());
 
         using var client = application.CreateClient();
         var response = await client.GetAsync($"/capabilities/{stubCapability.Id}");
@@ -108,6 +112,7 @@ public class TestCapabilityRoutes
             .Build();
         application.ReplaceService<IRbacPermissionGrantRepository>(new StubRbacPermissionGrantRepository());
         application.ReplaceService<IRbacRoleGrantRepository>(new StubRbacRoleGrantRepository());
+        application.ReplaceService<IPermissionQuery>(new StubPermissionQuery());
 
         using var client = application.CreateClient();
         var response = await client.GetAsync($"/capabilities/{stubCapability.Id}");

--- a/src/SelfService.Tests/Infrastructure/Api/TestCapabilityTopicsRoutes.cs
+++ b/src/SelfService.Tests/Infrastructure/Api/TestCapabilityTopicsRoutes.cs
@@ -19,6 +19,7 @@ public class TestCapabilityTopicsRoutes
             .Build();
         application.ReplaceService<IRbacPermissionGrantRepository>(new StubRbacPermissionGrantRepository());
         application.ReplaceService<IRbacRoleGrantRepository>(new StubRbacRoleGrantRepository());
+        application.ReplaceService<IPermissionQuery>(new StubPermissionQuery());
 
         using var client = application.CreateClient();
         var response = await client.GetAsync($"/capabilities/{stubCapability.Id}");
@@ -43,6 +44,7 @@ public class TestCapabilityTopicsRoutes
             .Build();
         application.ReplaceService<IRbacPermissionGrantRepository>(new StubRbacPermissionGrantRepository());
         application.ReplaceService<IRbacRoleGrantRepository>(new StubRbacRoleGrantRepository());
+        application.ReplaceService<IPermissionQuery>(new StubPermissionQuery());
 
         using var client = application.CreateClient();
         var response = await client.GetAsync($"/capabilities/{stubCapability.Id}");
@@ -71,6 +73,7 @@ public class TestCapabilityTopicsRoutes
             .Build();
         application.ReplaceService<IRbacPermissionGrantRepository>(new StubRbacPermissionGrantRepository());
         application.ReplaceService<IRbacRoleGrantRepository>(new StubRbacRoleGrantRepository());
+        application.ReplaceService<IPermissionQuery>(new StubPermissionQuery());
 
         using var client = application.CreateClient();
         var response = await client.GetAsync($"/capabilities/{stubCapability.Id}");
@@ -99,6 +102,7 @@ public class TestCapabilityTopicsRoutes
             .Build();
         application.ReplaceService<IRbacPermissionGrantRepository>(new StubRbacPermissionGrantRepository());
         application.ReplaceService<IRbacRoleGrantRepository>(new StubRbacRoleGrantRepository());
+        application.ReplaceService<IPermissionQuery>(new StubPermissionQuery());
 
         using var client = application.CreateClient();
         var response = await client.GetAsync($"/capabilities/{stubCapability.Id}");

--- a/src/SelfService.Tests/TestDoubles/StubPermissionQuery.cs
+++ b/src/SelfService.Tests/TestDoubles/StubPermissionQuery.cs
@@ -1,0 +1,19 @@
+using SelfService.Domain.Models;
+using SelfService.Domain.Queries;
+
+namespace SelfService.Tests.TestDoubles;
+
+public class StubPermissionQuery : IPermissionQuery
+{
+    public StubPermissionQuery() { }
+
+    public Task<IList<RbacPermissionGrant>> FindUserGroupPermissionsByUserId(string userId)
+    {
+        return Task.FromResult<IList<RbacPermissionGrant>>(new List<RbacPermissionGrant>());
+    }
+
+    public Task<IList<RbacRoleGrant>> FindUserGroupRolesByUserId(string userId)
+    {
+        return Task.FromResult<IList<RbacRoleGrant>>(new List<RbacRoleGrant>());
+    }
+}

--- a/src/SelfService/Configuration/Rbac.cs
+++ b/src/SelfService/Configuration/Rbac.cs
@@ -7,7 +7,6 @@ public static class Rbac
 {
     public static void AddRbac(this WebApplicationBuilder builder)
     {
-        // For testing purposes, TODO: replace with implementation that uses DB & repository
         builder.Services.AddTransient<IRbacApplicationService, RbacApplicationService>();
         builder.Services.AddTransient<AuthChecker>();
     }

--- a/src/SelfService/Domain/Services/AuthorizationService.cs
+++ b/src/SelfService/Domain/Services/AuthorizationService.cs
@@ -15,6 +15,7 @@ public class AuthorizationService : IAuthorizationService
     private readonly IKafkaTopicRepository _kafkaTopicRepository;
     private readonly IMembershipApplicationRepository _membershipApplicationRepository;
     private readonly IHttpContextAccessor _httpContextAccessor;
+    private readonly IRbacApplicationService _rbacApplicationService;
 
     public AuthorizationService(
         ILogger<AuthorizationService> logger,
@@ -25,12 +26,14 @@ public class AuthorizationService : IAuthorizationService
         IMessageContractRepository messageContractRepository,
         IKafkaTopicRepository kafkaTopicRepository,
         IMembershipApplicationRepository membershipApplicationRepository,
-        IHttpContextAccessor httpContextAccessor
+        IHttpContextAccessor httpContextAccessor,
+        IRbacApplicationService rbacApplicationService
     )
     {
         _logger = logger;
         _membershipQuery = membershipQuery;
         _kafkaClusterAccessRepository = kafkaClusterAccessRepository;
+        _rbacApplicationService = rbacApplicationService;
         _awsAccountRepository = awsAccountRepository;
         _azureResourceRepository = azureResourceRepository;
         _messageContractRepository = messageContractRepository;
@@ -242,7 +245,21 @@ public class AuthorizationService : IAuthorizationService
 
     public async Task<bool> CanDeleteCapability(UserId userId, CapabilityId capabilityId)
     {
-        return await _membershipQuery.HasActiveMembership(userId, capabilityId);
+        return (
+            await _rbacApplicationService.IsUserPermitted(
+                userId,
+                new List<Permission>
+                {
+                    new()
+                    {
+                        Namespace = RbacNamespace.CapabilityManagement,
+                        Name = "request-deletion",
+                        AccessType = RbacAccessType.Capability,
+                    },
+                },
+                capabilityId
+            )
+        ).Permitted();
     }
 
     public bool CanSynchronizeAwsECRAndDatabaseECR(PortalUser portalUser)


### PR DESCRIPTION
# What changed
- A single auth check (deleting capabilities) now check RBAC instead of previous logic
- Added test stubs related to RBAC