### PR TITLE
permission matrix manipulation

### DIFF
--- a/src/SelfService.Tests/TestDoubles/StubAuthenticationService.cs
+++ b/src/SelfService.Tests/TestDoubles/StubAuthenticationService.cs
@@ -150,6 +150,11 @@ public class StubAuthorizationService : IAuthorizationService
         return await Task.FromResult(_authorized);
     }
 
+    public bool CanManagePermissionMatrix(PortalUser portalUser)
+    {
+        return _authorized;
+    }
+
     public bool CanSynchronizeAwsECRAndDatabaseECR(PortalUser portalUser)
     {
         return _authorized;

--- a/src/SelfService.Tests/TestDoubles/StupRbacApplicationService.cs
+++ b/src/SelfService.Tests/TestDoubles/StupRbacApplicationService.cs
@@ -68,6 +68,11 @@ public class StubRbacApplicationService : IRbacApplicationService
         throw new NotImplementedException();
     }
 
+    public Task<List<RbacPermissionGrant>> GetPermissionGrantsForRoleIgnoreCase(string roleId)
+    {
+        throw new NotImplementedException();
+    }
+
     public Task<List<RbacPermissionGrant>> GetPermissionGrantsForRoleGrants(List<RbacRoleGrant> roleGrants)
     {
         throw new NotImplementedException();

--- a/src/SelfService.Tests/TestDoubles/StupRbacApplicationService.cs
+++ b/src/SelfService.Tests/TestDoubles/StupRbacApplicationService.cs
@@ -152,4 +152,9 @@ public class StubRbacApplicationService : IRbacApplicationService
     {
         throw new NotImplementedException();
     }
+
+    public Task SetPermissionsForRole(string roleId, List<RolePermissionEntry> permissions)
+    {
+        return Task.CompletedTask;
+    }
 }

--- a/src/SelfService/Application/IRbacApplicationService.cs
+++ b/src/SelfService/Application/IRbacApplicationService.cs
@@ -11,6 +11,7 @@ public interface IRbacApplicationService
     Task<List<RbacRoleGrant>> GetRoleGrantsForUser(string user);
     Task<List<RbacPermissionGrant>> GetPermissionGrantsForGroup(string groupId);
     Task<List<RbacPermissionGrant>> GetPermissionGrantsForRole(string roleId);
+    Task<List<RbacPermissionGrant>> GetPermissionGrantsForRoleIgnoreCase(string roleId);
     Task<List<RbacPermissionGrant>> GetPermissionGrantsForCapability(string capabilityId);
     Task<List<RbacRoleGrant>> GetRoleGrantsForCapability(string capabilityId);
     Task<List<RbacRoleGrant>> GetRoleGrantsForGroup(string groupId);

--- a/src/SelfService/Application/IRbacApplicationService.cs
+++ b/src/SelfService/Application/IRbacApplicationService.cs
@@ -28,4 +28,5 @@ public interface IRbacApplicationService
     Task DeleteGroup(string user, string groupId);
     Task<RbacGroupMember> GrantGroupGrant(string user, RbacGroupMember membership);
     Task RevokeGroupGrant(string user, RbacGroupMember membership);
+    Task SetPermissionsForRole(string roleId, List<RolePermissionEntry> permissions);
 }

--- a/src/SelfService/Application/RbacApplicationService.cs
+++ b/src/SelfService/Application/RbacApplicationService.cs
@@ -190,7 +190,7 @@ public class RbacApplicationService : IRbacApplicationService
         );
     }
 
-    private async Task<List<RbacPermissionGrant>> GetPermissionGrantsForRoleIgnoreCase(string roleId)
+    public async Task<List<RbacPermissionGrant>> GetPermissionGrantsForRoleIgnoreCase(string roleId)
     {
         return await _cache.GetOrAddAsync(
             CacheConst.PermissionGrantsForRoleIgnoreCase,

--- a/src/SelfService/Application/RbacApplicationService.cs
+++ b/src/SelfService/Application/RbacApplicationService.cs
@@ -713,7 +713,7 @@ public class RbacApplicationService : IRbacApplicationService
     [TransactionalBoundary]
     public async Task SetPermissionsForRole(string roleId, List<RolePermissionEntry> permissions)
     {
-        var existing = await GetPermissionGrantsForRole(roleId);
+        var existing = await GetPermissionGrantsForRoleIgnoreCase(roleId);
         foreach (var grant in existing)
             await _permissionGrantRepository.Remove(grant.Id);
 

--- a/src/SelfService/Application/RbacApplicationService.cs
+++ b/src/SelfService/Application/RbacApplicationService.cs
@@ -709,6 +709,28 @@ public class RbacApplicationService : IRbacApplicationService
 
         return resp.PermissionMatrix.Any(x => x.Value.Permitted);
     }
+
+    [TransactionalBoundary]
+    public async Task SetPermissionsForRole(string roleId, List<RolePermissionEntry> permissions)
+    {
+        var existing = await GetPermissionGrantsForRole(roleId);
+        foreach (var grant in existing)
+            await _permissionGrantRepository.Remove(grant.Id);
+
+        foreach (var p in permissions)
+            await _permissionGrantRepository.Add(
+                RbacPermissionGrant.New(
+                    AssignedEntityType.Role,
+                    roleId,
+                    p.Namespace,
+                    p.PermissionName,
+                    p.AccessType,
+                    ""
+                )
+            );
+
+        _cache.Reset();
+    }
 }
 
 public class Permission
@@ -860,3 +882,5 @@ public class PermittedResponse
         return PermissionMatrix.All(kv => kv.Value.Permitted != false);
     }
 }
+
+public record RolePermissionEntry(RbacNamespace Namespace, string PermissionName, RbacAccessType AccessType);

--- a/src/SelfService/Domain/Services/AuthorizationService.cs
+++ b/src/SelfService/Domain/Services/AuthorizationService.cs
@@ -573,6 +573,11 @@ public class AuthorizationService : IAuthorizationService
         ).Permitted();
     }
 
+    public bool CanManagePermissionMatrix(PortalUser portalUser)
+    {
+        return IsCloudEngineerEnabled(portalUser);
+    }
+
     public bool CanSynchronizeAwsECRAndDatabaseECR(PortalUser portalUser)
     {
         return IsCloudEngineerEnabled(portalUser);

--- a/src/SelfService/Domain/Services/IAuthorizationService.cs
+++ b/src/SelfService/Domain/Services/IAuthorizationService.cs
@@ -32,6 +32,7 @@ public interface IAuthorizationService
     Task<bool> CanDeleteCapability(UserId userId, CapabilityId capabilityId);
     bool CanViewDeletedCapabilities(PortalUser portalUser);
     bool CanSynchronizeAwsECRAndDatabaseECR(PortalUser portalUser);
+    bool CanManagePermissionMatrix(PortalUser portalUser);
     Task<bool> CanGetCapabilityJsonMetadata(PortalUser portalUser, CapabilityId capabilityId);
     Task<bool> CanSetCapabilityJsonMetadata(PortalUser portalUser, CapabilityId capabilityId);
     bool CanBypassMembershipApprovals(PortalUser portalUser);

--- a/src/SelfService/Infrastructure/Api/RBAC/RbacController.cs
+++ b/src/SelfService/Infrastructure/Api/RBAC/RbacController.cs
@@ -386,7 +386,7 @@ public class RbacController : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest, "application/problem+json")]
     public async Task<IActionResult> SetRolePermissions(string roleId, [FromBody] SetRolePermissionsRequest request)
     {
-        if (!_authorizationService.CanSynchronizeAwsECRAndDatabaseECR(User.ToPortalUser()))
+        if (!_authorizationService.CanManagePermissionMatrix(User.ToPortalUser()))
             return Unauthorized(
                 new ProblemDetails
                 {

--- a/src/SelfService/Infrastructure/Api/RBAC/RbacController.cs
+++ b/src/SelfService/Infrastructure/Api/RBAC/RbacController.cs
@@ -20,6 +20,7 @@ public class RbacController : ControllerBase
     private readonly IRbacApplicationService _rbacApplicationService;
     private readonly IPermissionQuery _permissionQuery;
     private readonly ApiResourceFactory _apiResourceFactory;
+    private readonly IAuthorizationService _authorizationService;
 
     public RbacController(
         IRbacApplicationService rbacApplicationService,
@@ -31,6 +32,7 @@ public class RbacController : ControllerBase
         _rbacApplicationService = rbacApplicationService;
         _permissionQuery = permissionQuery;
         _apiResourceFactory = apiResourceFactory;
+        _authorizationService = authorizationService;
     }
 
     [HttpGet("me")]
@@ -348,4 +350,88 @@ public class RbacController : ControllerBase
         var resp = await _rbacApplicationService.IsUserPermitted(request.UserId, request.Permissions, request.Objectid);
         return Ok(_apiResourceFactory.Convert(resp));
     }
+
+    [HttpGet("permission-matrix")]
+    [ProducesResponseType(typeof(PermissionMatrixResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public async Task<IActionResult> GetPermissionMatrix()
+    {
+        if (!User.TryGetUserId(out _))
+            return Unauthorized();
+
+        var roles = await _rbacApplicationService.GetAssignableRoles();
+        var permissions = Permission.BootstrapPermissions();
+
+        var grants = new List<PermissionMatrixGrantDto>();
+        foreach (var role in roles)
+        {
+            var roleGrants = await _rbacApplicationService.GetPermissionGrantsForRole(role.Id.ToString());
+            grants.AddRange(
+                roleGrants.Select(g => new PermissionMatrixGrantDto(role.Id.ToString(), g.Namespace.ToString(), g.Permission))
+            );
+        }
+
+        return Ok(
+            new PermissionMatrixResponse(
+                roles.Select(RbacRoleDTO.FromRbacRole).ToList(),
+                permissions.Select(p => new PermissionDto(p.Namespace.ToString(), p.Name, p.Description, p.AccessType.ToString())).ToList(),
+                grants
+            )
+        );
+    }
+
+    [HttpPut("permission-matrix/role/{roleId:required}")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized, "application/problem+json")]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest, "application/problem+json")]
+    public async Task<IActionResult> SetRolePermissions(string roleId, [FromBody] SetRolePermissionsRequest request)
+    {
+        if (!_authorizationService.CanSynchronizeAwsECRAndDatabaseECR(User.ToPortalUser()))
+            return Unauthorized(
+                new ProblemDetails
+                {
+                    Title = "Forbidden",
+                    Detail = "Only cloud engineers can modify the permission matrix.",
+                }
+            );
+
+        var allPermissions = Permission.BootstrapPermissions();
+        var unknownPermissions = request.Permissions
+            .Where(p => !allPermissions.Any(ap => ap.Namespace.ToString() == p.Namespace && ap.Name == p.Name))
+            .ToList();
+
+        if (unknownPermissions.Any())
+            return BadRequest(
+                new ProblemDetails
+                {
+                    Title = "Unknown permissions",
+                    Detail = $"The following permissions are not recognised: {string.Join(", ", unknownPermissions.Select(p => $"{p.Namespace}/{p.Name}"))}",
+                }
+            );
+
+        var entries = request.Permissions
+            .Select(p =>
+            {
+                var matching = allPermissions.First(ap => ap.Namespace.ToString() == p.Namespace && ap.Name == p.Name);
+                return new RolePermissionEntry(matching.Namespace, matching.Name, matching.AccessType);
+            })
+            .ToList();
+
+        await _rbacApplicationService.SetPermissionsForRole(roleId, entries);
+        return NoContent();
+    }
 }
+
+public record PermissionDto(string Namespace, string Name, string Description, string AccessType);
+
+public record PermissionMatrixGrantDto(string RoleId, string Namespace, string Permission);
+
+public record SetRolePermissionEntry(string Namespace, string Name);
+
+public record SetRolePermissionsRequest(List<SetRolePermissionEntry> Permissions);
+
+public record PermissionMatrixResponse(
+    List<RbacRoleDTO> Roles,
+    List<PermissionDto> Permissions,
+    List<PermissionMatrixGrantDto> Grants
+);

--- a/src/SelfService/Infrastructure/Api/RBAC/RbacController.cs
+++ b/src/SelfService/Infrastructure/Api/RBAC/RbacController.cs
@@ -367,14 +367,25 @@ public class RbacController : ControllerBase
         {
             var roleGrants = await _rbacApplicationService.GetPermissionGrantsForRoleIgnoreCase(role.Id.ToString());
             grants.AddRange(
-                roleGrants.Select(g => new PermissionMatrixGrantDto(role.Id.ToString(), g.Namespace.ToString(), g.Permission))
+                roleGrants.Select(g => new PermissionMatrixGrantDto(
+                    role.Id.ToString(),
+                    g.Namespace.ToString(),
+                    g.Permission
+                ))
             );
         }
 
         return Ok(
             new PermissionMatrixResponse(
                 roles.Select(RbacRoleDTO.FromRbacRole).ToList(),
-                permissions.Select(p => new PermissionDto(p.Namespace.ToString(), p.Name, p.Description, p.AccessType.ToString())).ToList(),
+                permissions
+                    .Select(p => new PermissionDto(
+                        p.Namespace.ToString(),
+                        p.Name,
+                        p.Description,
+                        p.AccessType.ToString()
+                    ))
+                    .ToList(),
                 grants
             )
         );
@@ -396,8 +407,10 @@ public class RbacController : ControllerBase
             );
 
         var allPermissions = Permission.BootstrapPermissions();
-        var unknownPermissions = request.Permissions
-            .Where(p => !allPermissions.Any(ap => ap.Namespace.ToString() == p.Namespace && ap.Name == p.Name))
+        var unknownPermissions = request
+            .Permissions.Where(p =>
+                !allPermissions.Any(ap => ap.Namespace.ToString() == p.Namespace && ap.Name == p.Name)
+            )
             .ToList();
 
         if (unknownPermissions.Any())
@@ -405,12 +418,13 @@ public class RbacController : ControllerBase
                 new ProblemDetails
                 {
                     Title = "Unknown permissions",
-                    Detail = $"The following permissions are not recognised: {string.Join(", ", unknownPermissions.Select(p => $"{p.Namespace}/{p.Name}"))}",
+                    Detail =
+                        $"The following permissions are not recognised: {string.Join(", ", unknownPermissions.Select(p => $"{p.Namespace}/{p.Name}"))}",
                 }
             );
 
-        var entries = request.Permissions
-            .Select(p =>
+        var entries = request
+            .Permissions.Select(p =>
             {
                 var matching = allPermissions.First(ap => ap.Namespace.ToString() == p.Namespace && ap.Name == p.Name);
                 return new RolePermissionEntry(matching.Namespace, matching.Name, matching.AccessType);

--- a/src/SelfService/Infrastructure/Api/RBAC/RbacController.cs
+++ b/src/SelfService/Infrastructure/Api/RBAC/RbacController.cs
@@ -365,7 +365,7 @@ public class RbacController : ControllerBase
         var grants = new List<PermissionMatrixGrantDto>();
         foreach (var role in roles)
         {
-            var roleGrants = await _rbacApplicationService.GetPermissionGrantsForRole(role.Id.ToString());
+            var roleGrants = await _rbacApplicationService.GetPermissionGrantsForRoleIgnoreCase(role.Id.ToString());
             grants.AddRange(
                 roleGrants.Select(g => new PermissionMatrixGrantDto(role.Id.ToString(), g.Namespace.ToString(), g.Permission))
             );


### PR DESCRIPTION
🌟 Changes:
- Adds endpoint for any authenticated user to fetch the current RBAC rules
- Adds endpoint for cloudengineers (outside RBAC) to manipulate RBAC rules

🎶 Notes:
The new endpoint for getting `rbac/permission-matrix` sort of supercedes the existing one for `rbac/get-assignable-permissions`. We should at least keep the old one until the frontend is updated.

It feels weird to have something called `Bootstrap` that is used for more than just bootstrapping 🫣 


❓ Question:
It seems okay that we have to update one role at a time when updating permissions.
However, it feels a little clunky in the frontend.
Should we simply allow PUTting all the permissions into the system in one fell swoop?