### PR TITLE
Remove Guest as an assignable role

### DIFF
--- a/src/SelfService.Tests/Infrastructure/Api/ApiApplication.cs
+++ b/src/SelfService.Tests/Infrastructure/Api/ApiApplication.cs
@@ -146,13 +146,6 @@ public class ApiApplication : WebApplicationFactory<Program>
                 SelfService.Application.StubRequirementsMetricService
             >();
 
-            // Replace RbacRoleRepository with an empty stub to avoid database dependency in tests.
-            // Individual tests can replace it with a configured instance if needed.
-            services.RemoveAll<SelfService.Infrastructure.Persistence.IRbacRoleRepository>();
-            services.AddTransient<SelfService.Infrastructure.Persistence.IRbacRoleRepository>(
-                _ => new SelfService.Tests.TestDoubles.StubRbacRoleRepository()
-            );
-
             services
                 .AddAuthentication(FakeAuthenticationSchemeDefaults.AuthenticationScheme)
                 .AddScheme<FakeAuthenticationSchemeOptions, FakeAuthenticationHandler>(

--- a/src/SelfService.Tests/Infrastructure/Api/ApiApplication.cs
+++ b/src/SelfService.Tests/Infrastructure/Api/ApiApplication.cs
@@ -146,6 +146,13 @@ public class ApiApplication : WebApplicationFactory<Program>
                 SelfService.Application.StubRequirementsMetricService
             >();
 
+            // Replace RbacRoleRepository with an empty stub to avoid database dependency in tests.
+            // Individual tests can replace it with a configured instance if needed.
+            services.RemoveAll<SelfService.Infrastructure.Persistence.IRbacRoleRepository>();
+            services.AddTransient<SelfService.Infrastructure.Persistence.IRbacRoleRepository>(
+                _ => new SelfService.Tests.TestDoubles.StubRbacRoleRepository()
+            );
+
             services
                 .AddAuthentication(FakeAuthenticationSchemeDefaults.AuthenticationScheme)
                 .AddScheme<FakeAuthenticationSchemeOptions, FakeAuthenticationHandler>(

--- a/src/SelfService.Tests/TestDoubles/StubPermissionQuery.cs
+++ b/src/SelfService.Tests/TestDoubles/StubPermissionQuery.cs
@@ -16,4 +16,9 @@ public class StubPermissionQuery : IPermissionQuery
     {
         return Task.FromResult<IList<RbacRoleGrant>>(new List<RbacRoleGrant>());
     }
+
+    public Task<List<RbacPermissionGrant>> FindGuestPermissions()
+    {
+        return Task.FromResult(new List<RbacPermissionGrant>());
+    }
 }

--- a/src/SelfService.Tests/TestDoubles/StubRbacRoleRepository.cs
+++ b/src/SelfService.Tests/TestDoubles/StubRbacRoleRepository.cs
@@ -1,0 +1,52 @@
+using SelfService.Domain.Models;
+using SelfService.Infrastructure.Persistence;
+
+namespace SelfService.Tests.TestDoubles;
+
+public class StubRbacRoleRepository : IRbacRoleRepository
+{
+    private readonly List<RbacRole> _roles;
+
+    public StubRbacRoleRepository(params RbacRole[] roles)
+    {
+        _roles = roles.ToList();
+    }
+
+    public Task Add(RbacRole model)
+    {
+        _roles.Add(model);
+        return Task.CompletedTask;
+    }
+
+    public Task<bool> Exists(RbacRoleId id)
+    {
+        return Task.FromResult(_roles.Any(r => r.Id == id));
+    }
+
+    public Task<RbacRole?> FindById(RbacRoleId id)
+    {
+        return Task.FromResult(_roles.FirstOrDefault(r => r.Id == id));
+    }
+
+    public Task<RbacRole?> FindByPredicate(Func<RbacRole, bool> predicate)
+    {
+        return Task.FromResult(_roles.FirstOrDefault(predicate));
+    }
+
+    public Task<RbacRole> Remove(RbacRoleId id)
+    {
+        var role = _roles.First(r => r.Id == id);
+        _roles.Remove(role);
+        return Task.FromResult(role);
+    }
+
+    public Task<List<RbacRole>> GetAll()
+    {
+        return Task.FromResult(_roles.ToList());
+    }
+
+    public Task<List<RbacRole>> GetAllWithPredicate(Func<RbacRole, bool> predicate)
+    {
+        return Task.FromResult(_roles.Where(predicate).ToList());
+    }
+}

--- a/src/SelfService.Tests/TestDoubles/StupRbacApplicationService.cs
+++ b/src/SelfService.Tests/TestDoubles/StupRbacApplicationService.cs
@@ -95,7 +95,7 @@ public class StubRbacApplicationService : IRbacApplicationService
 
     public Task<List<RbacRole>> GetAssignableRoles()
     {
-        return Task.FromResult(_assignableRoles ?? new List<RbacRole>());
+        return Task.FromResult((_assignableRoles ?? new List<RbacRole>()).Where(r => r.Name != "Guest").ToList());
     }
 
     public Task GrantPermission(string user, RbacPermissionGrant permissionGrant)

--- a/src/SelfService/Application/RbacApplicationService.cs
+++ b/src/SelfService/Application/RbacApplicationService.cs
@@ -79,8 +79,14 @@ public class RbacApplicationService : IRbacApplicationService
             combinedPermissions = combinedPermissions
                 .Concat(
                     guestPermissions.Select(p => new RbacPermissionGrant(
-                        p.Id, p.CreatedAt, p.AssignedEntityType, p.AssignedEntityId,
-                        p.Namespace, p.Permission, RbacAccessType.Capability, objectId
+                        p.Id,
+                        p.CreatedAt,
+                        p.AssignedEntityType,
+                        p.AssignedEntityId,
+                        p.Namespace,
+                        p.Permission,
+                        RbacAccessType.Capability,
+                        objectId
                     ))
                 )
                 .ToList();

--- a/src/SelfService/Application/RbacApplicationService.cs
+++ b/src/SelfService/Application/RbacApplicationService.cs
@@ -66,7 +66,10 @@ public class RbacApplicationService : IRbacApplicationService
 
         // If the user has no explicit capability role for this resource, apply Guest role permissions as default
         var isCapabilityCheck = permissions.Any(p => p.AccessType == RbacAccessType.Capability);
-        if (isCapabilityCheck && !combinedRoles.Any(rg => rg.Type == RbacAccessType.Capability && rg.Resource == objectId))
+        if (
+            isCapabilityCheck
+            && !combinedRoles.Any(rg => rg.Type == RbacAccessType.Capability && rg.Resource == objectId)
+        )
         {
             var guestRole = (await GetAllRoles()).FirstOrDefault(r => r.Name == "Guest");
             if (guestRole != null)

--- a/src/SelfService/Application/RbacApplicationService.cs
+++ b/src/SelfService/Application/RbacApplicationService.cs
@@ -64,6 +64,29 @@ public class RbacApplicationService : IRbacApplicationService
         var combinedPermissions = userPermissions.Concat(groupPermissions).ToList();
         var combinedRoles = userRoles.Concat(groupRoles).ToList();
 
+        // If the user has no explicit capability role for this resource, apply Guest role permissions as default
+        var isCapabilityCheck = permissions.Any(p => p.AccessType == RbacAccessType.Capability);
+        if (isCapabilityCheck && !combinedRoles.Any(rg => rg.Type == RbacAccessType.Capability && rg.Resource == objectId))
+        {
+            var guestRole = (await GetAllRoles()).FirstOrDefault(r => r.Name == "Guest");
+            if (guestRole != null)
+            {
+                combinedRoles = combinedRoles
+                    .Append(
+                        new RbacRoleGrant(
+                            id: RbacRoleGrantId.New(),
+                            roleId: guestRole.Id,
+                            createdAt: DateTime.UtcNow,
+                            assignedEntityType: AssignedEntityType.User,
+                            assignedEntityId: user,
+                            type: RbacAccessType.Capability,
+                            resource: objectId
+                        )
+                    )
+                    .ToList();
+            }
+        }
+
         var accessGrantingPermissionGrants = combinedPermissions.FindAll(p =>
         {
             var policyGrantsAccess = false;
@@ -248,10 +271,17 @@ public class RbacApplicationService : IRbacApplicationService
         );
     }
 
-    // TODO: Implement when repo is available
-    public async Task<List<RbacRole>> GetAssignableRoles()
+    private async Task<List<RbacRole>> GetAllRoles()
     {
         return await _cache.GetOrAddAsync(CacheConst.AssignableRoles, "all", () => _roleRepository.GetAll());
+    }
+
+    // Returns roles that can be assigned to capability members. Guest is excluded as it is a system-level
+    // default role applied implicitly to users without an explicit capability role.
+    public async Task<List<RbacRole>> GetAssignableRoles()
+    {
+        var allRoles = await GetAllRoles();
+        return allRoles.Where(r => r.Name != "Guest").ToList();
     }
 
     [TransactionalBoundary]
@@ -434,6 +464,14 @@ public class RbacApplicationService : IRbacApplicationService
                 if (roleGrant.Resource == null)
                 {
                     throw new BadHttpRequestException("Capability ID is required for capability role grants");
+                }
+
+                var guestRoleCheck = (await GetAllRoles()).FirstOrDefault(r => r.Name == "Guest");
+                if (guestRoleCheck != null && roleGrant.RoleId == guestRoleCheck.Id)
+                {
+                    throw new BadHttpRequestException(
+                        "Guest role cannot be directly assigned to a capability. It is the implicit default role for users without an explicit capability role."
+                    );
                 }
 
                 var existingCapabilityGrant = await _roleGrantRepository.FindByPredicate(rg =>

--- a/src/SelfService/Application/RbacApplicationService.cs
+++ b/src/SelfService/Application/RbacApplicationService.cs
@@ -71,23 +71,19 @@ public class RbacApplicationService : IRbacApplicationService
             && !combinedRoles.Any(rg => rg.Type == RbacAccessType.Capability && rg.Resource == objectId)
         )
         {
-            var guestRole = (await GetAllRoles()).FirstOrDefault(r => r.Name == "Guest");
-            if (guestRole != null)
-            {
-                combinedRoles = combinedRoles
-                    .Append(
-                        new RbacRoleGrant(
-                            id: RbacRoleGrantId.New(),
-                            roleId: guestRole.Id,
-                            createdAt: DateTime.UtcNow,
-                            assignedEntityType: AssignedEntityType.User,
-                            assignedEntityId: user,
-                            type: RbacAccessType.Capability,
-                            resource: objectId
-                        )
-                    )
-                    .ToList();
-            }
+            var guestPermissions = await _cache.GetOrAddAsync(
+                CacheConst.GuestPermissions,
+                "global",
+                () => _permissionQuery.FindGuestPermissions()
+            );
+            combinedPermissions = combinedPermissions
+                .Concat(
+                    guestPermissions.Select(p => new RbacPermissionGrant(
+                        p.Id, p.CreatedAt, p.AssignedEntityType, p.AssignedEntityId,
+                        p.Namespace, p.Permission, RbacAccessType.Capability, objectId
+                    ))
+                )
+                .ToList();
         }
 
         var accessGrantingPermissionGrants = combinedPermissions.FindAll(p =>

--- a/src/SelfService/Domain/Queries/IPermissionQuery.cs
+++ b/src/SelfService/Domain/Queries/IPermissionQuery.cs
@@ -6,4 +6,5 @@ public interface IPermissionQuery
 {
     Task<IList<RbacPermissionGrant>> FindUserGroupPermissionsByUserId(string userId);
     Task<IList<RbacRoleGrant>> FindUserGroupRolesByUserId(string userId);
+    Task<List<RbacPermissionGrant>> FindGuestPermissions();
 }

--- a/src/SelfService/Infrastructure/Persistence/Queries/PermissionsQuery.cs
+++ b/src/SelfService/Infrastructure/Persistence/Queries/PermissionsQuery.cs
@@ -40,4 +40,23 @@ public class PermissionsQuery : IPermissionQuery
 
         return await query.ToListAsync();
     }
+
+    public async Task<List<RbacPermissionGrant>> FindGuestPermissions()
+    {
+        var guestRole = await _dbContext.RbacRoles.FirstOrDefaultAsync(r =>
+            r.Name.ToLower() == "guest"
+        );
+
+        if (guestRole == null)
+            return new List<RbacPermissionGrant>();
+
+        var guestRoleId = guestRole.Id.ToString();
+
+        return await _dbContext.RbacPermissionGrants
+            .Where(pg =>
+                pg.AssignedEntityType == AssignedEntityType.Role
+                && pg.AssignedEntityId.ToLower() == guestRoleId.ToLower()
+            )
+            .ToListAsync();
+    }
 }

--- a/src/SelfService/Infrastructure/Persistence/Queries/PermissionsQuery.cs
+++ b/src/SelfService/Infrastructure/Persistence/Queries/PermissionsQuery.cs
@@ -43,17 +43,15 @@ public class PermissionsQuery : IPermissionQuery
 
     public async Task<List<RbacPermissionGrant>> FindGuestPermissions()
     {
-        var guestRole = await _dbContext.RbacRoles.FirstOrDefaultAsync(r =>
-            r.Name.ToLower() == "guest"
-        );
+        var guestRole = await _dbContext.RbacRoles.FirstOrDefaultAsync(r => r.Name.ToLower() == "guest");
 
         if (guestRole == null)
             return new List<RbacPermissionGrant>();
 
         var guestRoleId = guestRole.Id.ToString();
 
-        return await _dbContext.RbacPermissionGrants
-            .Where(pg =>
+        return await _dbContext
+            .RbacPermissionGrants.Where(pg =>
                 pg.AssignedEntityType == AssignedEntityType.Role
                 && pg.AssignedEntityId.ToLower() == guestRoleId.ToLower()
             )

--- a/src/SelfService/Infrastructure/Persistence/RbacCache.cs
+++ b/src/SelfService/Infrastructure/Persistence/RbacCache.cs
@@ -44,5 +44,6 @@ class CacheConst
     public const string RoleGrantsForGroup = "RoleGrantsForGroup";
     public const string GroupsForUser = "GroupsForUser";
     public const string AssignableRoles = "AssignableRoles";
+    public const string GuestPermissions = "GuestPermissions";
     public const string SystemGroups = "SystemGroups";
 }


### PR DESCRIPTION
🌟 Changes:
- Filter out 'Guest' role from list of assignable roles (we still want the Guest role in the system, it is just not assignable).
- Fail requests asking to assign the Guest role (should people attempt to use the API directly).
- When checking permissions, always include the guest permissions (cached at the request level)