### PR TITLE
fetch all roles for matrix

### DIFF
--- a/src/SelfService.Tests/TestDoubles/StupRbacApplicationService.cs
+++ b/src/SelfService.Tests/TestDoubles/StupRbacApplicationService.cs
@@ -98,6 +98,11 @@ public class StubRbacApplicationService : IRbacApplicationService
         return Task.FromResult(_roleGrants ?? new List<RbacRoleGrant>());
     }
 
+    public Task<List<RbacRole>> GetAllRoles()
+    {
+        return Task.FromResult(_assignableRoles ?? new List<RbacRole>());
+    }
+
     public Task<List<RbacRole>> GetAssignableRoles()
     {
         return Task.FromResult((_assignableRoles ?? new List<RbacRole>()).Where(r => r.Name != "Guest").ToList());

--- a/src/SelfService/Application/IRbacApplicationService.cs
+++ b/src/SelfService/Application/IRbacApplicationService.cs
@@ -18,6 +18,7 @@ public interface IRbacApplicationService
     Task<List<RbacGroup>> GetGroupsForUser(string user);
     Task<List<RbacGroup>> GetSystemGroups();
     Task<List<RbacRole>> GetAssignableRoles();
+    Task<List<RbacRole>> GetAllRoles();
     Task GrantPermission(string user, RbacPermissionGrant permissionGrant);
     Task RevokePermission(string user, string id);
     Task GrantRoleGrant(string user, RbacRoleGrant roleGrant);

--- a/src/SelfService/Application/RbacApplicationService.cs
+++ b/src/SelfService/Application/RbacApplicationService.cs
@@ -276,16 +276,21 @@ public class RbacApplicationService : IRbacApplicationService
         );
     }
 
-    private async Task<List<RbacRole>> GetAllRoles()
+    private async Task<List<RbacRole>> GetAllRolesInternal()
     {
         return await _cache.GetOrAddAsync(CacheConst.AssignableRoles, "all", () => _roleRepository.GetAll());
+    }
+
+    public async Task<List<RbacRole>> GetAllRoles()
+    {
+        return await GetAllRolesInternal();
     }
 
     // Returns roles that can be assigned to capability members. Guest is excluded as it is a system-level
     // default role applied implicitly to users without an explicit capability role.
     public async Task<List<RbacRole>> GetAssignableRoles()
     {
-        var allRoles = await GetAllRoles();
+        var allRoles = await GetAllRolesInternal();
         return allRoles.Where(r => r.Name != "Guest").ToList();
     }
 
@@ -471,7 +476,7 @@ public class RbacApplicationService : IRbacApplicationService
                     throw new BadHttpRequestException("Capability ID is required for capability role grants");
                 }
 
-                var guestRoleCheck = (await GetAllRoles()).FirstOrDefault(r => r.Name == "Guest");
+                var guestRoleCheck = (await GetAllRolesInternal()).FirstOrDefault(r => r.Name == "Guest");
                 if (guestRoleCheck != null && roleGrant.RoleId == guestRoleCheck.Id)
                 {
                     throw new BadHttpRequestException(

--- a/src/SelfService/Infrastructure/Api/RBAC/RbacController.cs
+++ b/src/SelfService/Infrastructure/Api/RBAC/RbacController.cs
@@ -359,7 +359,7 @@ public class RbacController : ControllerBase
         if (!User.TryGetUserId(out _))
             return Unauthorized();
 
-        var roles = await _rbacApplicationService.GetAssignableRoles();
+        var roles = await _rbacApplicationService.GetAllRoles();
         var permissions = Permission.BootstrapPermissions();
 
         var grants = new List<PermissionMatrixGrantDto>();


### PR DESCRIPTION
💡 Reason:
Frontend received too few roles for the permission matrix, due to our filtering of assignable roles

🌟 Changes:
- Create internal function for fetching all roles
- Create two helper functions for returning roles to outside calls, based on internal function