### PR TITLE
Indicate ready for deletion as kafka event

### DIFF
--- a/src/SelfService.Tests/Application/TestActOnPendingCapabilityDeletions.cs
+++ b/src/SelfService.Tests/Application/TestActOnPendingCapabilityDeletions.cs
@@ -1,0 +1,88 @@
+using Moq;
+using SelfService.Application;
+using SelfService.Domain.Events;
+using SelfService.Domain.Models;
+
+namespace SelfService.Tests.Application;
+
+public class TestActOnPendingCapabilityDeletions
+{
+    private static CapabilityApplicationService BuildServiceWithCapabilities(
+        IEnumerable<Capability> pendingCapabilities
+    )
+    {
+        var repoMock = new Mock<ICapabilityRepository>();
+        repoMock
+            .Setup(r => r.GetAllPendingDeletionFor(It.IsAny<int>()))
+            .ReturnsAsync(pendingCapabilities);
+
+        return A.CapabilityApplicationService.WithCapabilityRepository(repoMock.Object).Build();
+    }
+
+    [Fact]
+    public async Task raises_capability_ready_for_deletion_event_for_old_pending_capability()
+    {
+        var capability = A.Capability
+            .WithStatus(CapabilityStatusOptions.PendingDeletion)
+            .WithModifiedAt(DateTime.UtcNow.AddDays(-8))
+            .Build();
+
+        var sut = BuildServiceWithCapabilities([capability]);
+
+        await sut.ActOnPendingCapabilityDeletions();
+
+        var events = capability.GetEvents().ToList();
+        var evt = Assert.Single(events);
+        var readyForDeletion = Assert.IsType<CapabilityReadyForDeletion>(evt);
+        Assert.Equal(capability.Id.ToString(), readyForDeletion.CapabilityId);
+    }
+
+    [Fact]
+    public async Task sets_capability_status_to_ongoing_deletion()
+    {
+        var capability = A.Capability
+            .WithStatus(CapabilityStatusOptions.PendingDeletion)
+            .WithModifiedAt(DateTime.UtcNow.AddDays(-8))
+            .Build();
+
+        var sut = BuildServiceWithCapabilities([capability]);
+
+        await sut.ActOnPendingCapabilityDeletions();
+
+        Assert.Equal(CapabilityStatusOptions.OngoingDeletion, capability.Status);
+    }
+
+    [Fact]
+    public async Task raises_event_for_each_pending_capability()
+    {
+        var capability1 = A.Capability
+            .WithId("cap-one")
+            .WithStatus(CapabilityStatusOptions.PendingDeletion)
+            .WithModifiedAt(DateTime.UtcNow.AddDays(-8))
+            .Build();
+
+        var capability2 = A.Capability
+            .WithId("cap-two")
+            .WithStatus(CapabilityStatusOptions.PendingDeletion)
+            .WithModifiedAt(DateTime.UtcNow.AddDays(-10))
+            .Build();
+
+        var sut = BuildServiceWithCapabilities([capability1, capability2]);
+
+        await sut.ActOnPendingCapabilityDeletions();
+
+        Assert.Single(capability1.GetEvents());
+        Assert.Single(capability2.GetEvents());
+        Assert.Equal(CapabilityStatusOptions.OngoingDeletion, capability1.Status);
+        Assert.Equal(CapabilityStatusOptions.OngoingDeletion, capability2.Status);
+    }
+
+    [Fact]
+    public async Task does_nothing_when_no_pending_capabilities()
+    {
+        var sut = BuildServiceWithCapabilities([]);
+
+        // Should complete without throwing
+        await sut.ActOnPendingCapabilityDeletions();
+    }
+}

--- a/src/SelfService.Tests/Application/TestActOnPendingCapabilityDeletions.cs
+++ b/src/SelfService.Tests/Application/TestActOnPendingCapabilityDeletions.cs
@@ -12,9 +12,7 @@ public class TestActOnPendingCapabilityDeletions
     )
     {
         var repoMock = new Mock<ICapabilityRepository>();
-        repoMock
-            .Setup(r => r.GetAllPendingDeletionFor(It.IsAny<int>()))
-            .ReturnsAsync(pendingCapabilities);
+        repoMock.Setup(r => r.GetAllPendingDeletionFor(It.IsAny<int>())).ReturnsAsync(pendingCapabilities);
 
         return A.CapabilityApplicationService.WithCapabilityRepository(repoMock.Object).Build();
     }
@@ -22,8 +20,8 @@ public class TestActOnPendingCapabilityDeletions
     [Fact]
     public async Task raises_capability_ready_for_deletion_event_for_old_pending_capability()
     {
-        var capability = A.Capability
-            .WithStatus(CapabilityStatusOptions.PendingDeletion)
+        var capability = A
+            .Capability.WithStatus(CapabilityStatusOptions.PendingDeletion)
             .WithModifiedAt(DateTime.UtcNow.AddDays(-8))
             .Build();
 
@@ -40,8 +38,8 @@ public class TestActOnPendingCapabilityDeletions
     [Fact]
     public async Task sets_capability_status_to_ongoing_deletion()
     {
-        var capability = A.Capability
-            .WithStatus(CapabilityStatusOptions.PendingDeletion)
+        var capability = A
+            .Capability.WithStatus(CapabilityStatusOptions.PendingDeletion)
             .WithModifiedAt(DateTime.UtcNow.AddDays(-8))
             .Build();
 
@@ -55,14 +53,14 @@ public class TestActOnPendingCapabilityDeletions
     [Fact]
     public async Task raises_event_for_each_pending_capability()
     {
-        var capability1 = A.Capability
-            .WithId("cap-one")
+        var capability1 = A
+            .Capability.WithId("cap-one")
             .WithStatus(CapabilityStatusOptions.PendingDeletion)
             .WithModifiedAt(DateTime.UtcNow.AddDays(-8))
             .Build();
 
-        var capability2 = A.Capability
-            .WithId("cap-two")
+        var capability2 = A
+            .Capability.WithId("cap-two")
             .WithStatus(CapabilityStatusOptions.PendingDeletion)
             .WithModifiedAt(DateTime.UtcNow.AddDays(-10))
             .Build();

--- a/src/SelfService.Tests/Application/TestCapabilityDeletionIntegration.cs
+++ b/src/SelfService.Tests/Application/TestCapabilityDeletionIntegration.cs
@@ -1,0 +1,146 @@
+using Dafda.Consuming;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using SelfService.Application;
+using SelfService.Domain.Events;
+using SelfService.Domain.Models;
+using SelfService.Domain.Policies;
+using SelfService.Infrastructure.Persistence;
+
+namespace SelfService.Tests.Application;
+
+public class TestCapabilityDeletionIntegration
+{
+    private static (CapabilityRepository, CapabilityApplicationService) BuildService(
+        SelfServiceDbContext dbContext
+    )
+    {
+        var repo = A.CapabilityRepository.WithDbContext(dbContext).Build();
+        var service = A.CapabilityApplicationService.WithCapabilityRepository(repo).Build();
+        return (repo, service);
+    }
+
+    [Fact]
+    [Trait("Category", "InMemoryDatabase")]
+    public async Task act_on_pending_deletions_transitions_old_capability_to_ongoing_deletion_in_db()
+    {
+        await using var databaseFactory = new InMemoryDatabaseFactory();
+        var dbContext = await databaseFactory.CreateSelfServiceDbContext();
+        var (repo, service) = BuildService(dbContext);
+
+        var capability = A.Capability
+            .WithId("pending-old")
+            .WithStatus(CapabilityStatusOptions.PendingDeletion)
+            .WithModifiedAt(DateTime.UtcNow.AddDays(-8))
+            .Build();
+        await repo.Add(capability);
+        await dbContext.SaveChangesAsync();
+
+        await service.ActOnPendingCapabilityDeletions();
+        await dbContext.SaveChangesAsync();
+
+        var stored = await dbContext.Capabilities.SingleAsync(c => c.Id == capability.Id);
+        Assert.Equal(CapabilityStatusOptions.OngoingDeletion, stored.Status);
+    }
+
+    [Fact]
+    [Trait("Category", "InMemoryDatabase")]
+    public async Task act_on_pending_deletions_does_not_affect_recently_pending_capability()
+    {
+        await using var databaseFactory = new InMemoryDatabaseFactory();
+        var dbContext = await databaseFactory.CreateSelfServiceDbContext();
+        var (repo, service) = BuildService(dbContext);
+
+        var recentPending = A.Capability
+            .WithId("pending-new")
+            .WithStatus(CapabilityStatusOptions.PendingDeletion)
+            .WithModifiedAt(DateTime.UtcNow.AddDays(-1))
+            .Build();
+        await repo.Add(recentPending);
+        await dbContext.SaveChangesAsync();
+
+        await service.ActOnPendingCapabilityDeletions();
+        await dbContext.SaveChangesAsync();
+
+        var stored = await dbContext.Capabilities.SingleAsync(c => c.Id == recentPending.Id);
+        Assert.Equal(CapabilityStatusOptions.PendingDeletion, stored.Status);
+    }
+
+    [Fact]
+    [Trait("Category", "InMemoryDatabase")]
+    public async Task act_on_pending_deletions_raises_ready_for_deletion_event()
+    {
+        await using var databaseFactory = new InMemoryDatabaseFactory();
+        var dbContext = await databaseFactory.CreateSelfServiceDbContext();
+        var (repo, service) = BuildService(dbContext);
+
+        var capability = A.Capability
+            .WithId("pending-old")
+            .WithStatus(CapabilityStatusOptions.PendingDeletion)
+            .WithModifiedAt(DateTime.UtcNow.AddDays(-8))
+            .Build();
+        await repo.Add(capability);
+        await dbContext.SaveChangesAsync();
+
+        await service.ActOnPendingCapabilityDeletions();
+
+        var evt = Assert.Single(capability.GetEvents());
+        var readyForDeletion = Assert.IsType<CapabilityReadyForDeletion>(evt);
+        Assert.Equal(capability.Id.ToString(), readyForDeletion.CapabilityId);
+    }
+
+    [Fact]
+    [Trait("Category", "InMemoryDatabase")]
+    public async Task mark_capability_as_deleted_transitions_ongoing_deletion_to_deleted_in_db()
+    {
+        await using var databaseFactory = new InMemoryDatabaseFactory();
+        var dbContext = await databaseFactory.CreateSelfServiceDbContext();
+        var (repo, service) = BuildService(dbContext);
+
+        var capability = A.Capability
+            .WithId("ongoing-cap")
+            .WithStatus(CapabilityStatusOptions.OngoingDeletion)
+            .Build();
+        await repo.Add(capability);
+        await dbContext.SaveChangesAsync();
+
+        await service.MarkCapabilityAsDeleted(capability.Id);
+        await dbContext.SaveChangesAsync();
+
+        var stored = await dbContext.Capabilities.SingleAsync(c => c.Id == capability.Id);
+        Assert.Equal(CapabilityStatusOptions.Deleted, stored.Status);
+    }
+
+    [Fact]
+    [Trait("Category", "InMemoryDatabase")]
+    public async Task handler_marks_capability_as_deleted_in_db_when_receiving_ready_for_deletion_event()
+    {
+        await using var databaseFactory = new InMemoryDatabaseFactory();
+        var dbContext = await databaseFactory.CreateSelfServiceDbContext();
+        var (repo, service) = BuildService(dbContext);
+
+        var capability = A.Capability
+            .WithId("ongoing-cap")
+            .WithStatus(CapabilityStatusOptions.OngoingDeletion)
+            .Build();
+        await repo.Add(capability);
+        await dbContext.SaveChangesAsync();
+
+#pragma warning disable CS0618
+        var handler = new MarkCapabilityAsDeletedHandler(
+            NullLogger<MarkCapabilityAsDeletedHandler>.Instance,
+            service
+        );
+        await handler.Handle(
+            new CapabilityReadyForDeletion { CapabilityId = capability.Id },
+            new MessageHandlerContext()
+        );
+#pragma warning restore CS0618
+
+        await dbContext.SaveChangesAsync();
+
+        var stored = await dbContext.Capabilities.SingleAsync(c => c.Id == capability.Id);
+        Assert.Equal(CapabilityStatusOptions.Deleted, stored.Status);
+    }
+}

--- a/src/SelfService.Tests/Application/TestCapabilityDeletionIntegration.cs
+++ b/src/SelfService.Tests/Application/TestCapabilityDeletionIntegration.cs
@@ -12,9 +12,7 @@ namespace SelfService.Tests.Application;
 
 public class TestCapabilityDeletionIntegration
 {
-    private static (CapabilityRepository, CapabilityApplicationService) BuildService(
-        SelfServiceDbContext dbContext
-    )
+    private static (CapabilityRepository, CapabilityApplicationService) BuildService(SelfServiceDbContext dbContext)
     {
         var repo = A.CapabilityRepository.WithDbContext(dbContext).Build();
         var service = A.CapabilityApplicationService.WithCapabilityRepository(repo).Build();
@@ -29,8 +27,8 @@ public class TestCapabilityDeletionIntegration
         var dbContext = await databaseFactory.CreateSelfServiceDbContext();
         var (repo, service) = BuildService(dbContext);
 
-        var capability = A.Capability
-            .WithId("pending-old")
+        var capability = A
+            .Capability.WithId("pending-old")
             .WithStatus(CapabilityStatusOptions.PendingDeletion)
             .WithModifiedAt(DateTime.UtcNow.AddDays(-8))
             .Build();
@@ -52,8 +50,8 @@ public class TestCapabilityDeletionIntegration
         var dbContext = await databaseFactory.CreateSelfServiceDbContext();
         var (repo, service) = BuildService(dbContext);
 
-        var recentPending = A.Capability
-            .WithId("pending-new")
+        var recentPending = A
+            .Capability.WithId("pending-new")
             .WithStatus(CapabilityStatusOptions.PendingDeletion)
             .WithModifiedAt(DateTime.UtcNow.AddDays(-1))
             .Build();
@@ -75,8 +73,8 @@ public class TestCapabilityDeletionIntegration
         var dbContext = await databaseFactory.CreateSelfServiceDbContext();
         var (repo, service) = BuildService(dbContext);
 
-        var capability = A.Capability
-            .WithId("pending-old")
+        var capability = A
+            .Capability.WithId("pending-old")
             .WithStatus(CapabilityStatusOptions.PendingDeletion)
             .WithModifiedAt(DateTime.UtcNow.AddDays(-8))
             .Build();
@@ -98,10 +96,7 @@ public class TestCapabilityDeletionIntegration
         var dbContext = await databaseFactory.CreateSelfServiceDbContext();
         var (repo, service) = BuildService(dbContext);
 
-        var capability = A.Capability
-            .WithId("ongoing-cap")
-            .WithStatus(CapabilityStatusOptions.OngoingDeletion)
-            .Build();
+        var capability = A.Capability.WithId("ongoing-cap").WithStatus(CapabilityStatusOptions.OngoingDeletion).Build();
         await repo.Add(capability);
         await dbContext.SaveChangesAsync();
 
@@ -120,18 +115,12 @@ public class TestCapabilityDeletionIntegration
         var dbContext = await databaseFactory.CreateSelfServiceDbContext();
         var (repo, service) = BuildService(dbContext);
 
-        var capability = A.Capability
-            .WithId("ongoing-cap")
-            .WithStatus(CapabilityStatusOptions.OngoingDeletion)
-            .Build();
+        var capability = A.Capability.WithId("ongoing-cap").WithStatus(CapabilityStatusOptions.OngoingDeletion).Build();
         await repo.Add(capability);
         await dbContext.SaveChangesAsync();
 
 #pragma warning disable CS0618
-        var handler = new MarkCapabilityAsDeletedHandler(
-            NullLogger<MarkCapabilityAsDeletedHandler>.Instance,
-            service
-        );
+        var handler = new MarkCapabilityAsDeletedHandler(NullLogger<MarkCapabilityAsDeletedHandler>.Instance, service);
         await handler.Handle(
             new CapabilityReadyForDeletion { CapabilityId = capability.Id },
             new MessageHandlerContext()

--- a/src/SelfService.Tests/Domain/Policies/TestMarkCapabilityAsDeletedHandler.cs
+++ b/src/SelfService.Tests/Domain/Policies/TestMarkCapabilityAsDeletedHandler.cs
@@ -1,0 +1,68 @@
+using Dafda.Consuming;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using SelfService.Application;
+using SelfService.Domain.Events;
+using SelfService.Domain.Models;
+using SelfService.Domain.Policies;
+
+namespace SelfService.Tests.Domain.Policies;
+
+public class TestMarkCapabilityAsDeletedHandler
+{
+    private static MarkCapabilityAsDeletedHandler BuildHandler(ICapabilityApplicationService service) =>
+        new MarkCapabilityAsDeletedHandler(NullLogger<MarkCapabilityAsDeletedHandler>.Instance, service);
+
+#pragma warning disable CS0618
+    private static readonly MessageHandlerContext EmptyContext = new MessageHandlerContext();
+#pragma warning restore CS0618
+
+    [Fact]
+    public async Task calls_mark_as_deleted_with_correct_capability_id()
+    {
+        var capabilityId = "my-capability";
+        var appServiceMock = new Mock<ICapabilityApplicationService>();
+
+        var sut = BuildHandler(appServiceMock.Object);
+
+        await sut.Handle(
+            new CapabilityReadyForDeletion { CapabilityId = capabilityId },
+            EmptyContext
+        );
+
+        appServiceMock.Verify(
+            x => x.MarkCapabilityAsDeleted(CapabilityId.Parse(capabilityId)),
+            Times.Once
+        );
+    }
+
+    [Fact]
+    public async Task does_not_call_service_when_capability_id_is_null()
+    {
+        var appServiceMock = new Mock<ICapabilityApplicationService>();
+
+        var sut = BuildHandler(appServiceMock.Object);
+
+        await sut.Handle(
+            new CapabilityReadyForDeletion { CapabilityId = null },
+            EmptyContext
+        );
+
+        appServiceMock.Verify(x => x.MarkCapabilityAsDeleted(It.IsAny<CapabilityId>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task does_not_call_service_when_capability_id_is_empty()
+    {
+        var appServiceMock = new Mock<ICapabilityApplicationService>();
+
+        var sut = BuildHandler(appServiceMock.Object);
+
+        await sut.Handle(
+            new CapabilityReadyForDeletion { CapabilityId = "" },
+            EmptyContext
+        );
+
+        appServiceMock.Verify(x => x.MarkCapabilityAsDeleted(It.IsAny<CapabilityId>()), Times.Never);
+    }
+}

--- a/src/SelfService.Tests/Domain/Policies/TestMarkCapabilityAsDeletedHandler.cs
+++ b/src/SelfService.Tests/Domain/Policies/TestMarkCapabilityAsDeletedHandler.cs
@@ -25,15 +25,9 @@ public class TestMarkCapabilityAsDeletedHandler
 
         var sut = BuildHandler(appServiceMock.Object);
 
-        await sut.Handle(
-            new CapabilityReadyForDeletion { CapabilityId = capabilityId },
-            EmptyContext
-        );
+        await sut.Handle(new CapabilityReadyForDeletion { CapabilityId = capabilityId }, EmptyContext);
 
-        appServiceMock.Verify(
-            x => x.MarkCapabilityAsDeleted(CapabilityId.Parse(capabilityId)),
-            Times.Once
-        );
+        appServiceMock.Verify(x => x.MarkCapabilityAsDeleted(CapabilityId.Parse(capabilityId)), Times.Once);
     }
 
     [Fact]
@@ -43,10 +37,7 @@ public class TestMarkCapabilityAsDeletedHandler
 
         var sut = BuildHandler(appServiceMock.Object);
 
-        await sut.Handle(
-            new CapabilityReadyForDeletion { CapabilityId = null },
-            EmptyContext
-        );
+        await sut.Handle(new CapabilityReadyForDeletion { CapabilityId = null }, EmptyContext);
 
         appServiceMock.Verify(x => x.MarkCapabilityAsDeleted(It.IsAny<CapabilityId>()), Times.Never);
     }
@@ -58,10 +49,7 @@ public class TestMarkCapabilityAsDeletedHandler
 
         var sut = BuildHandler(appServiceMock.Object);
 
-        await sut.Handle(
-            new CapabilityReadyForDeletion { CapabilityId = "" },
-            EmptyContext
-        );
+        await sut.Handle(new CapabilityReadyForDeletion { CapabilityId = "" }, EmptyContext);
 
         appServiceMock.Verify(x => x.MarkCapabilityAsDeleted(It.IsAny<CapabilityId>()), Times.Never);
     }

--- a/src/SelfService.Tests/Infrastructure/Messaging/TestDafdaSerializationDeserialization.cs
+++ b/src/SelfService.Tests/Infrastructure/Messaging/TestDafdaSerializationDeserialization.cs
@@ -299,7 +299,6 @@ public class TestDafdaSerializationDeserialization
                 RecipientLogId = "log-id",
                 Status = "Sent",
                 ErrorMessage = null,
-
             }
         );
     }

--- a/src/SelfService.Tests/Infrastructure/Messaging/TestDafdaSerializationDeserialization.cs
+++ b/src/SelfService.Tests/Infrastructure/Messaging/TestDafdaSerializationDeserialization.cs
@@ -299,6 +299,21 @@ public class TestDafdaSerializationDeserialization
                 RecipientLogId = "log-id",
                 Status = "Sent",
                 ErrorMessage = null,
+
+            }
+        );
+    }
+
+    [Fact]
+    public async Task dafda_serialize_deserialize_capability_ready_for_deletion()
+    {
+        await dafda_serialize_deserialize(new CapabilityReadyForDeletion());
+        await dafda_serialize_deserialize(
+            new CapabilityReadyForDeletion
+            {
+                CapabilityId = TestCapabilityId,
+                RequestedBy = TestUser,
+                RequestedAt = DateTime.UtcNow,
             }
         );
     }

--- a/src/SelfService.Tests/Infrastructure/Persistence/TestCapabilityRepository.cs
+++ b/src/SelfService.Tests/Infrastructure/Persistence/TestCapabilityRepository.cs
@@ -40,6 +40,11 @@ public class TestCapabilityRepository
                 .WithStatus(CapabilityStatusOptions.PendingDeletion)
                 .WithModifiedAt(DateTime.UtcNow.AddDays(-8))
         );
+        await repo.Add(
+            A.Capability.WithId("ongoing-deletion")
+                .WithStatus(CapabilityStatusOptions.OngoingDeletion)
+                .WithModifiedAt(DateTime.UtcNow.AddDays(-9))
+        );
         await repo.Add(A.Capability.WithId("deleted").WithStatus(CapabilityStatusOptions.Deleted));
 
         await dbContext.SaveChangesAsync();
@@ -47,7 +52,7 @@ public class TestCapabilityRepository
         var allCapabilities = await repo.GetAll(); // does not get deleted
         var readyForDeletion = await repo.GetAllPendingDeletionFor(days: 7);
 
-        Assert.Equal(4, allCapabilities.Count());
+        Assert.Equal(5, allCapabilities.Count());
         Assert.Single(readyForDeletion);
         Assert.Equal("pending-old", readyForDeletion.First().Id);
     }

--- a/src/SelfService/Application/CapabilityApplicationService.cs
+++ b/src/SelfService/Application/CapabilityApplicationService.cs
@@ -266,14 +266,38 @@ public class CapabilityApplicationService : ICapabilityApplicationService
 
             await _ticketingSystem.CreateTicket(message, headers);
 
-            capability.MarkAsDeleted();
+            capability.RaiseEvent(new CapabilityReadyForDeletion
+            {
+                CapabilityId = capability.Id,
+                RequestedBy = capability.ModifiedBy,
+                RequestedAt = capability.ModifiedAt,
+            });
+
+            capability.StartDeletion();
 
             _logger.LogInformation(
-                "Deletion of Capability {CapabilityId} begun and removed from UI. Requested by {RequestedBy}.",
+                "Capability {CapabilityId} is ready for deletion and event has been raised. Requested by {RequestedBy}.",
                 capability.Id,
                 capability.ModifiedBy
             );
         }
+    }
+
+    [TransactionalBoundary]
+    public async Task MarkCapabilityAsDeleted(CapabilityId capabilityId)
+    {
+        var capability = await _capabilityRepository.FindBy(capabilityId);
+        if (capability is null)
+        {
+            throw EntityNotFoundException<Capability>.UsingId(capabilityId);
+        }
+
+        capability.MarkAsDeleted();
+
+        _logger.LogInformation(
+            "Capability {CapabilityId} has been marked as deleted.",
+            capability.Id
+        );
     }
 
     [TransactionalBoundary]

--- a/src/SelfService/Application/CapabilityApplicationService.cs
+++ b/src/SelfService/Application/CapabilityApplicationService.cs
@@ -266,12 +266,14 @@ public class CapabilityApplicationService : ICapabilityApplicationService
 
             await _ticketingSystem.CreateTicket(message, headers);
 
-            capability.RaiseEvent(new CapabilityReadyForDeletion
-            {
-                CapabilityId = capability.Id,
-                RequestedBy = capability.ModifiedBy,
-                RequestedAt = capability.ModifiedAt,
-            });
+            capability.RaiseEvent(
+                new CapabilityReadyForDeletion
+                {
+                    CapabilityId = capability.Id,
+                    RequestedBy = capability.ModifiedBy,
+                    RequestedAt = capability.ModifiedAt,
+                }
+            );
 
             capability.StartDeletion();
 
@@ -294,10 +296,7 @@ public class CapabilityApplicationService : ICapabilityApplicationService
 
         capability.MarkAsDeleted();
 
-        _logger.LogInformation(
-            "Capability {CapabilityId} has been marked as deleted.",
-            capability.Id
-        );
+        _logger.LogInformation("Capability {CapabilityId} has been marked as deleted.", capability.Id);
     }
 
     [TransactionalBoundary]

--- a/src/SelfService/Application/ICapabilityApplicationService.cs
+++ b/src/SelfService/Application/ICapabilityApplicationService.cs
@@ -29,6 +29,7 @@ public interface ICapabilityApplicationService
     Task RequestCapabilityDeletion(CapabilityId capabilityId, UserId userId);
     Task CancelCapabilityDeletionRequest(CapabilityId capabilityId, UserId userId);
     Task ActOnPendingCapabilityDeletions();
+    Task MarkCapabilityAsDeleted(CapabilityId capabilityId);
     Task SetJsonMetadata(CapabilityId capabilityId, string jsonMetadata);
     Task<string> GetJsonMetadata(CapabilityId capabilityId);
     Task<bool> DoesOnlyModifyRequiredProperties(string jsonMetadata, CapabilityId capabilityId);

--- a/src/SelfService/Domain/Events/CapabilityReadyForDeletion.cs
+++ b/src/SelfService/Domain/Events/CapabilityReadyForDeletion.cs
@@ -1,0 +1,12 @@
+using SelfService.Domain.Models;
+
+namespace SelfService.Domain.Events;
+
+public class CapabilityReadyForDeletion : IDomainEvent
+{
+    public string? CapabilityId { get; set; }
+    public string? RequestedBy { get; set; }
+    public DateTime? RequestedAt { get; set; }
+
+    public const string EventType = "capability-ready-for-deletion";
+}

--- a/src/SelfService/Domain/Models/Capability.cs
+++ b/src/SelfService/Domain/Models/Capability.cs
@@ -124,15 +124,24 @@ public class Capability : AggregateRoot<CapabilityId>
 
     public void MarkAsDeleted()
     {
-        if (Status != CapabilityStatusOptions.PendingDeletion)
+        if (Status != CapabilityStatusOptions.OngoingDeletion)
         {
-            throw new InvalidOperationException("Capability is not pending deletion");
+            throw new InvalidOperationException("Capability is not in ongoing deletion");
         }
 
         Status = CapabilityStatusOptions.Deleted;
         ModifiedAt = DateTime.UtcNow;
     }
+    public void StartDeletion()
+    {
+        if (Status != CapabilityStatusOptions.PendingDeletion)
+        {
+            throw new InvalidOperationException("Capability is not pending deletion");
+        }
 
+        Status = CapabilityStatusOptions.OngoingDeletion;
+        ModifiedAt = DateTime.UtcNow;
+    }
     public void UpdateRequirementScore(double score)
     {
         RequirementScore = score;

--- a/src/SelfService/Domain/Models/Capability.cs
+++ b/src/SelfService/Domain/Models/Capability.cs
@@ -132,6 +132,7 @@ public class Capability : AggregateRoot<CapabilityId>
         Status = CapabilityStatusOptions.Deleted;
         ModifiedAt = DateTime.UtcNow;
     }
+
     public void StartDeletion()
     {
         if (Status != CapabilityStatusOptions.PendingDeletion)
@@ -142,6 +143,7 @@ public class Capability : AggregateRoot<CapabilityId>
         Status = CapabilityStatusOptions.OngoingDeletion;
         ModifiedAt = DateTime.UtcNow;
     }
+
     public void UpdateRequirementScore(double score)
     {
         RequirementScore = score;

--- a/src/SelfService/Domain/Models/CapabilityStatusOptions.cs
+++ b/src/SelfService/Domain/Models/CapabilityStatusOptions.cs
@@ -4,6 +4,7 @@ public class CapabilityStatusOptions : ValueObject
 {
     public static readonly CapabilityStatusOptions Active = new("Active");
     public static readonly CapabilityStatusOptions PendingDeletion = new("Pending Deletion");
+    public static readonly CapabilityStatusOptions OngoingDeletion = new("Ongoing Deletion");
     public static readonly CapabilityStatusOptions Deleted = new("Deleted");
 
     private readonly string _value;
@@ -50,7 +51,7 @@ public class CapabilityStatusOptions : ValueObject
         return false;
     }
 
-    public static IReadOnlyCollection<CapabilityStatusOptions> Values => new[] { Active, PendingDeletion, Deleted };
+    public static IReadOnlyCollection<CapabilityStatusOptions> Values => new[] { Active, PendingDeletion, OngoingDeletion, Deleted };
 
     public static implicit operator CapabilityStatusOptions(string text) => Parse(text);
 

--- a/src/SelfService/Domain/Models/CapabilityStatusOptions.cs
+++ b/src/SelfService/Domain/Models/CapabilityStatusOptions.cs
@@ -51,7 +51,8 @@ public class CapabilityStatusOptions : ValueObject
         return false;
     }
 
-    public static IReadOnlyCollection<CapabilityStatusOptions> Values => new[] { Active, PendingDeletion, OngoingDeletion, Deleted };
+    public static IReadOnlyCollection<CapabilityStatusOptions> Values =>
+        new[] { Active, PendingDeletion, OngoingDeletion, Deleted };
 
     public static implicit operator CapabilityStatusOptions(string text) => Parse(text);
 

--- a/src/SelfService/Domain/Policies/MarkCapabilityAsDeletedHandler.cs
+++ b/src/SelfService/Domain/Policies/MarkCapabilityAsDeletedHandler.cs
@@ -1,0 +1,45 @@
+using Dafda.Consuming;
+using SelfService.Application;
+using SelfService.Domain.Events;
+using SelfService.Domain.Models;
+
+namespace SelfService.Domain.Policies;
+
+public class MarkCapabilityAsDeletedHandler : IMessageHandler<CapabilityReadyForDeletion>
+{
+    private readonly ILogger<MarkCapabilityAsDeletedHandler> _logger;
+    private readonly ICapabilityApplicationService _capabilityApplicationService;
+
+    public MarkCapabilityAsDeletedHandler(
+        ILogger<MarkCapabilityAsDeletedHandler> logger,
+        ICapabilityApplicationService capabilityApplicationService
+    )
+    {
+        _logger = logger;
+        _capabilityApplicationService = capabilityApplicationService;
+    }
+
+    public async Task Handle(CapabilityReadyForDeletion message, MessageHandlerContext context)
+    {
+        using var _ = _logger.BeginScope(
+            "Handling {MessageType} on {ImplementationType} with {CorrelationId} and {CausationId}",
+            context.MessageType,
+            GetType().Name,
+            context.CorrelationId,
+            context.CausationId
+        );
+
+        if (!CapabilityId.TryParse(message.CapabilityId, out var capabilityId))
+        {
+            _logger.LogWarning(
+                "Cannot mark capability as deleted because capability id \"{CapabilityId}\" is not valid - skipping message {MessageId}",
+                message.CapabilityId,
+                context.MessageId
+            );
+            return;
+        }
+
+        _logger.LogDebug("Marking capability {CapabilityId} as deleted", capabilityId);
+        await _capabilityApplicationService.MarkCapabilityAsDeleted(capabilityId);
+    }
+}

--- a/src/SelfService/Infrastructure/Messaging/ConsumerConfiguration.cs
+++ b/src/SelfService/Infrastructure/Messaging/ConsumerConfiguration.cs
@@ -25,6 +25,10 @@ public static class ConsumerConfiguration
                 .Register<CapabilityDeletionRequestSubmitted>(
                     messageType: CapabilityDeletionRequestSubmitted.EventType,
                     keySelector: x => x.CapabilityId!
+                )
+                .Register<CapabilityReadyForDeletion>(
+                    messageType: CapabilityReadyForDeletion.EventType,
+                    keySelector: x => x.CapabilityId!
                 );
 
             options
@@ -124,7 +128,10 @@ public static class ConsumerConfiguration
 
             options
                 .ForTopic($"{SelfServicePrefix}.capability")
-                .RegisterMessageHandler<CapabilityCreated, CapabilityCreatedHandler>(CapabilityCreated.EventType);
+                .RegisterMessageHandler<CapabilityCreated, CapabilityCreatedHandler>(CapabilityCreated.EventType)
+                .RegisterMessageHandler<CapabilityReadyForDeletion, MarkCapabilityAsDeletedHandler>(
+                    CapabilityReadyForDeletion.EventType
+                );
 
             options
                 .ForTopic($"{SelfServicePrefix}.awsaccount")

--- a/src/SelfService/Infrastructure/Persistence/Queries/CapabilityDeletionStatusQuery.cs
+++ b/src/SelfService/Infrastructure/Persistence/Queries/CapabilityDeletionStatusQuery.cs
@@ -15,6 +15,7 @@ public class CapabilityDeletionStatusQuery : ICapabilityDeletionStatusQuery
     public async Task<bool> IsPendingDeletion(CapabilityId capabilityId)
     {
         var capability = await _dbContext.Capabilities.FindAsync(capabilityId);
-        return capability?.Status == CapabilityStatusOptions.PendingDeletion;
+        return capability?.Status == CapabilityStatusOptions.PendingDeletion
+            || capability?.Status == CapabilityStatusOptions.OngoingDeletion;
     }
 }

--- a/src/SelfService/Infrastructure/Persistence/Queries/MyCapabilitiesOutstandingActionsQuery.cs
+++ b/src/SelfService/Infrastructure/Persistence/Queries/MyCapabilitiesOutstandingActionsQuery.cs
@@ -32,7 +32,8 @@ public class MyCapabilitiesOutstandingActionsQuery : IMyCapabilitiesOutstandingA
             c => c.Id,
             c => new CapabilityOutstandingActions
             {
-                IsPendingDeletion = c.Status == CapabilityStatusOptions.PendingDeletion,
+                IsPendingDeletion = c.Status == CapabilityStatusOptions.PendingDeletion
+                    || c.Status == CapabilityStatusOptions.OngoingDeletion,
                 PendingMembershipApplicationCount = pendingApplicationCounts.GetValueOrDefault(c.Id, 0),
             }
         );

--- a/src/SelfService/Infrastructure/Persistence/Queries/MyCapabilitiesOutstandingActionsQuery.cs
+++ b/src/SelfService/Infrastructure/Persistence/Queries/MyCapabilitiesOutstandingActionsQuery.cs
@@ -32,7 +32,8 @@ public class MyCapabilitiesOutstandingActionsQuery : IMyCapabilitiesOutstandingA
             c => c.Id,
             c => new CapabilityOutstandingActions
             {
-                IsPendingDeletion = c.Status == CapabilityStatusOptions.PendingDeletion
+                IsPendingDeletion =
+                    c.Status == CapabilityStatusOptions.PendingDeletion
                     || c.Status == CapabilityStatusOptions.OngoingDeletion,
                 PendingMembershipApplicationCount = pendingApplicationCounts.GetValueOrDefault(c.Id, 0),
             }


### PR DESCRIPTION
❗ Suggestion only

💡 Idea:
By sending an event when capabilities are ready to be deleted, other processes can react to this event too, automating deletion substeps

🌟 Changes:
- Background job checking pending deletion capabilities now emits an event for all capabilities which have been pending for 7 days.
- Creates a handler, reacting to the new event, marking capabilities as deleted.
- Reuses existing topic `cloudengineering.selfservice.capabilities`
- Added tests for the this new kafka flow
- Added an additional capability state `ongoing deletion`
